### PR TITLE
Minor cosmetics

### DIFF
--- a/pyblish_qml/models.py
+++ b/pyblish_qml/models.py
@@ -33,6 +33,7 @@ plugin_defaults = {
     "contextEnabled": False,
     "instanceEnabled": False,
     "pre11": True,
+    "verb": "unknown"
 }
 
 instance_defaults = {
@@ -282,6 +283,15 @@ class ItemModel(AbstractModel):
         item["itemType"] = "plugin"
         item["isToggled"] = not (0 <= plugin["order"] < 1)  # Not selectors
         item["hasCompatible"] = True
+
+        item["verb"] = {
+            "Selector": "Collect",
+            "Collector": "Collect",
+            "Validator": "Validate",
+            "Extractor": "Extract",
+            "Integrator": "Integrate",
+            "Conformer": "Integrate",
+        }[item["type"]]
 
         item = self.add_item(item)
         self.plugins.append(item)

--- a/pyblish_qml/qml/Overview.qml
+++ b/pyblish_qml/qml/Overview.qml
@@ -93,7 +93,7 @@ Item {
                 width: Math.floor(parent.width / 2.0)
                 height: parent.height
 
-                section.property: "object.type"
+                section.property: "object.verb"
 
                 onActionTriggered: {
                     if (action.name == "repair")


### PR DESCRIPTION
Labels now use verbs as opposed to nouns.

"Validators" -> "Validate"
"Extractors" -> "Extract"

Such that you can use names of your plug-ins to match.

"Validate bind pose"
"Extract Maya ASCII"

Etc.