### PR TITLE
- fixing qml typo

### DIFF
--- a/pyblish_qml/qml/List.qml
+++ b/pyblish_qml/qml/List.qml
@@ -61,7 +61,7 @@ ListView {
                 iconName: "adn"
                 iconSize: 12
                 tooltip: "This plug-in has actions"
-                enabled: object.actionsIconVisibleVisible ? true : false
+                enabled: object.actionsIconVisible ? true : false
                 color: object.actionPending ? "white"
                      : object.actionHasError ? Theme.dark.errorColor
                      : Theme.dark.successColor


### PR DESCRIPTION
Quite a huge mistake which meant Action icons weren't showing at all.

Clearly my test was not good at all :disappointed: 