### PR TITLE
fixed typo

### DIFF
--- a/pyblish_qml/qml/Pyblish/Theme.qml
+++ b/pyblish_qml/qml/Pyblish/Theme.qml
@@ -94,6 +94,6 @@ Object {
     FontLoader {source: Qt.resolvedUrl("fonts/opensans/OpenSans-Light.ttf")}
     FontLoader {source: Qt.resolvedUrl("fonts/opensans/OpenSans-LightItalic.ttf")}
     FontLoader {source: Qt.resolvedUrl("fonts/opensans/OpenSans-Regular.ttf")}
-    FontLoader {source: Qt.resolvedUrl("fonts/opensans/OpenSans-SemiBold.ttf")}
-    FontLoader {source: Qt.resolvedUrl("fonts/opensans/OpenSans-SemiBoldItalic.ttf")}
+    FontLoader {source: Qt.resolvedUrl("fonts/opensans/OpenSans-Semibold.ttf")}
+    FontLoader {source: Qt.resolvedUrl("fonts/opensans/OpenSans-SemiboldItalic.ttf")}
 }


### PR DESCRIPTION
was giving the following error on linux

``` bash
pyblish_qml/qml/Pyblish/Theme.qml:98:5: QML FontLoader: Cannot load font: "file:///software/rez/user_packages/lars/pyblish_qml/0.6.0/python/pyblish_qml/qml/Pyblish/fonts/opensans/OpenSans-SemiBoldItalic.ttf"
pyblish_qml/qml/Pyblish/Theme.qml:97:5: QML FontLoader: Cannot load font: "file:///software/rez/user_packages/lars/pyblish_qml/0.6.0/python/pyblish_qml/qml/Pyblish/fonts/opensans/OpenSans-SemiBold.ttf"

```