### PR TITLE
removed if not plug.active

### DIFF
--- a/pyblish_qml/control.py
+++ b/pyblish_qml/control.py
@@ -277,8 +277,6 @@ class Controller(QtCore.QObject):
         }
 
         for plug, instance in pyblish.logic.Iterator(plugins, context):
-            if not plug.active:
-                continue
 
             state["nextOrder"] = plug.order
 

--- a/pyblish_qml/control.py
+++ b/pyblish_qml/control.py
@@ -672,6 +672,9 @@ class Controller(QtCore.QObject):
                         base=pyblish.api.Collector.order):
                     continue
 
+                if not plugin.active:
+                    continue
+
                 collectors.append(plugin)
 
             self.run(collectors, context,

--- a/tests/test_control.py
+++ b/tests/test_control.py
@@ -547,3 +547,32 @@ def test_action_not_processed():
 
     assert len(validate_actions) == 0, (
         "ValidateAction should not have had an action")
+
+
+def test_inactive_collector():
+    """An inactive collector should not run"""
+
+    count = {"#": 0}
+
+    class MyInactiveCollector(pyblish.api.ContextPlugin):
+        order = pyblish.api.CollectorOrder
+        active = False
+
+        def process(self, context):
+            print("Ran %s" % type(self))
+            count["#"] += 1
+
+    class MyActiveCollector(pyblish.api.ContextPlugin):
+        order = pyblish.api.CollectorOrder
+        active = True
+
+        def process(self, context):
+            print("Ran %s" % type(self))
+            count["#"] += 10
+
+    pyblish.api.register_plugin(MyInactiveCollector)
+    pyblish.api.register_plugin(MyActiveCollector)
+
+    reset()
+
+    assert count["#"] == 10


### PR DESCRIPTION
Fixes Bug, if a plugin is set active=False and you manually activate it again, it won't get executed