### PR TITLE
Adding PyQt5 as an install dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -78,7 +78,7 @@ setup(
     },
     install_requires=[
         "pyblish-base>=1.4",
-        "python-qt5>=0.1.8"
+        "PyQt5>=5.7"
     ],
     entry_points={},
 )

--- a/setup.py
+++ b/setup.py
@@ -77,7 +77,8 @@ setup(
         ]
     },
     install_requires=[
-        "pyblish-base>=1.4"
+        "pyblish-base>=1.4",
+        "python-qt5>=0.1.8"
     ],
     entry_points={},
 )


### PR DESCRIPTION
As discussed in #209. I only tested the latest PyQt5 5.7, so I don't know whether it'll work on older versions.

Now I'm guessing we should also inform the user somehow that installing ```pyblish_qml``` via. pip+git will need python 3.5, or is the current README section about requirements enough?