### PR TITLE
Fix #218

### DIFF
--- a/pyblish_qml/control.py
+++ b/pyblish_qml/control.py
@@ -911,7 +911,8 @@ class Controller(QtCore.QObject):
         util.timer("publishing")
         stats = {"requestCount": self.host.stats()["totalRequestCount"]}
 
-        instance_iterator = models.ItemIterator(self.data["models"]["item"].instances)
+        instance_iterator = models.ItemIterator(
+            self.data["models"]["item"].instances)
         failed_instances = [p.id for p in instance_iterator
                             if p.hasError]
 
@@ -923,7 +924,8 @@ class Controller(QtCore.QObject):
             if p.id in failed_instances)
 
         # Filter items in GUI with items from host
-        index = self.data["proxies"]["plugin"].index(index, 0, QtCore.QModelIndex())
+        index = self.data["proxies"]["plugin"].index(
+            index, 0, QtCore.QModelIndex())
         index = self.data["proxies"]["plugin"].mapToSource(index)
         plugin = self.data["models"]["item"].items[index.row()]
         plugin.hasError = False

--- a/pyblish_qml/version.py
+++ b/pyblish_qml/version.py
@@ -1,7 +1,7 @@
 
 VERSION_MAJOR = 0
 VERSION_MINOR = 8
-VERSION_PATCH = 0
+VERSION_PATCH = 1
 
 version_info = (VERSION_MAJOR, VERSION_MINOR, VERSION_PATCH)
 version = '%i.%i.%i' % version_info


### PR DESCRIPTION
This fixes a bug where `active=False` on any plug-in would permanently disable it, even though it appears toggled in the GUI.

See #218 for details.