### PR TITLE
Improve startup performance

### DIFF
--- a/pyblish_qml/ipc/server.py
+++ b/pyblish_qml/ipc/server.py
@@ -240,20 +240,6 @@ def find_pyqt5(python):
         os.getenv("PYBLISH_QML_PYQT5")
     )
 
-    if pyqt5 is None:
-        try:
-            cmd = "import imp;print(imp.find_module('PyQt5')[1])"
-            pyqt5 = subprocess.check_output([python, "-c", cmd]).rstrip()
-
-            if six.PY3:
-                pyqt5 = pyqt5.decode("utf8")
-
-        except subprocess.CalledProcessError:
-            raise ValueError("Could not locate PyQt5")
-
-    elif "PyQt5" not in os.listdir(pyqt5):
-        raise ValueError("PyQt5 not found in '%s'" % pyqt5)
-
     return pyqt5
 
 

--- a/pyblish_qml/version.py
+++ b/pyblish_qml/version.py
@@ -1,7 +1,7 @@
 
 VERSION_MAJOR = 1
 VERSION_MINOR = 0
-VERSION_PATCH = 1
+VERSION_PATCH = 2
 
 version_info = (VERSION_MAJOR, VERSION_MINOR, VERSION_PATCH)
 version = '%i.%i.%i' % version_info


### PR DESCRIPTION
Not setting `PYBLISH_QML_PYQT5` implies an automatic search for PyQt5 on the provided Python's PYTHONPATH. But, the search is moot considering Python would already be searching for it when attempting to run the app. This meant that during startup, Python was instantiated twice; once to find PyQt5, and once to actually use it.

Assuming Python implies reading 50 mb off disk, this reduces the amount read from 100 mb to 50 mb, which in addition to PyQt5 libraries at another 50 mb means a (max) 33% reduction in startup time. In reality it will be less due to filesystem caching.