### PR TITLE
Implement support for adding a comment

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ Some data within each Instance and Context are special to QML.
 |:----------|:-----------------|:-------------------
 | `publish` | Instance         | The on/off state of the toggle.
 | `label`   | Context/Instance | Draw this instead of an instance's `name`
+| `comment` | Context          | Display and edit comment in GUI
 
 <br>
 

--- a/pyblish_qml/app.py
+++ b/pyblish_qml/app.py
@@ -53,12 +53,6 @@ class Window(QtQuick.QQuickView):
 
         return super(Window, self).event(event)
 
-    def keyPressEvent(self, event):
-        """Delegate keyboard events"""
-
-        if event.key() == QtCore.Qt.Key_Return:
-            return self.on_enter()
-
 
 class Application(QtGui.QGuiApplication):
     """Pyblish QML wrapper around QGuiApplication
@@ -169,7 +163,9 @@ class Application(QtGui.QGuiApplication):
             util.timer_end("ready", "Awaited statemachine for %.2f ms")
 
         self.controller.show.emit()
-        self.controller.reset()
+
+        # Allow time for QML to initialise
+        util.schedule(self.controller.reset, 500, channel="main")
 
     def hide(self):
         """Hide GUI

--- a/pyblish_qml/app.py
+++ b/pyblish_qml/app.py
@@ -242,8 +242,7 @@ def main(demo=False, aschild=False):
         service = ipc.service.MockService() if demo else ipc.service.Service()
         server = ipc.server.Server(service)
 
-        if demo:
-            proxy = ipc.server.Proxy(server)
-            proxy.show(settings.to_dict())
+        proxy = ipc.server.Proxy(server)
+        proxy.show(settings.to_dict())
 
         server.wait()

--- a/pyblish_qml/control.py
+++ b/pyblish_qml/control.py
@@ -719,12 +719,13 @@ class Controller(QtCore.QObject):
                       % abs(stats["requestCount"]))
 
             # Reset Context
-            context = self.data["models"]["item"].instances[0]
-            context.hasError = False
-            context.succeeded = False
-            context.processed = False
-            context.isProcessing = False
-            context.currentProgress = 0
+            context_item = self.data["models"]["item"].instances[0]
+            context_item.hasError = False
+            context_item.succeeded = False
+            context_item.processed = False
+            context_item.isProcessing = False
+            context_item.currentProgress = 0
+            context_item.label = context.data.get("label")
 
             self.initialised.emit()
 

--- a/pyblish_qml/control.py
+++ b/pyblish_qml/control.py
@@ -611,6 +611,7 @@ class Controller(QtCore.QObject):
             self.data.update({"comment": (summary, description)})
 
             # Notify subscribers of the comment
+            self.host.update(key="comment", value=comment)
             self.host.emit("commented", comment=comment)
 
             self.commented.emit()

--- a/pyblish_qml/control.py
+++ b/pyblish_qml/control.py
@@ -609,6 +609,10 @@ class Controller(QtCore.QObject):
             context = self.host.cached_context
             context.data["comment"] = comment
             self.data.update({"comment": (summary, description)})
+
+            # Notify subscribers of the comment
+            self.host.emit("commented", comment=comment)
+
             self.commented.emit()
 
         # Update local cache a little later

--- a/pyblish_qml/host.py
+++ b/pyblish_qml/host.py
@@ -110,7 +110,7 @@ def show(parent=None):
     try:
         service = ipc.service.Service()
         server = ipc.server.Server(service)
-    except:
+    except Exception:
         # If for some reason, the GUI fails to show.
         traceback.print_exc()
         return on_shown()

--- a/pyblish_qml/ipc/client.py
+++ b/pyblish_qml/ipc/client.py
@@ -73,6 +73,9 @@ class Proxy(object):
     def emit(self, signal, **kwargs):
         self._dispatch("emit", args=[signal, kwargs])
 
+    def update(self, key, value):
+        self._dispatch("update", args=[key, value])
+
     def _listen(self):
         """Listen for messages passed from parent
 

--- a/pyblish_qml/ipc/formatting.py
+++ b/pyblish_qml/ipc/formatting.py
@@ -131,6 +131,7 @@ def format_data(data):
         "family",
         "families",
         "publish",
+        "comment",
 
         # Provided by service.py
         "host",

--- a/pyblish_qml/ipc/service.py
+++ b/pyblish_qml/ipc/service.py
@@ -137,6 +137,10 @@ class Service(object):
 
         pyblish.api.emit(signal, **kwargs)
 
+    def update(self, key, value):
+        """Write data to context from GUI"""
+        self._context.data[key] = value
+
 
 class MockService(Service):
     def __init__(self, delay=0.01, *args, **kwargs):

--- a/pyblish_qml/qml/CommentBox.qml
+++ b/pyblish_qml/qml/CommentBox.qml
@@ -1,0 +1,130 @@
+import QtQuick 2.6
+import QtQuick.Layouts 1.1
+
+import Pyblish 0.1
+
+Rectangle {
+    id: root
+    clip: true
+    height: 0
+
+    color: Theme.backgroundColor
+
+    property bool isUp
+    property bool isMaximised
+
+    property alias summary: commentSummary.text
+    property alias description: commentDescription.text
+
+    property var readOnly: false
+
+    Behavior on height {
+        NumberAnimation {
+            duration: 500
+            easing.type: Easing.OutQuint
+        }
+    }
+
+    function up() {
+        isUp = true
+        commentSummary.forceActiveFocus()
+    }
+
+    function down() {
+        isUp = false
+        isMaximised = false
+    }
+
+    function toggle() {
+        isUp ? down() : up()
+    }
+
+    ColumnLayout {
+        anchors.fill: parent
+        anchors.margins: 5
+
+        View {
+            radius: 3
+            height: 27
+            elevation: -1
+            Layout.fillWidth: true
+
+            RowLayout {
+                anchors.fill: parent
+                anchors.margins: 5
+                
+                TextInput {
+                    id: commentSummary
+                    Layout.fillWidth: true
+                    Layout.fillHeight: true
+                    color: "white"
+                    selectionColor: "#222"
+                    readOnly: root.readOnly
+                    selectByMouse: true
+                    clip: true
+
+                    font.family: "Open Sans"
+                    font.weight: Font.Normal
+
+                    KeyNavigation.tab: commentDescription
+                    KeyNavigation.backtab: commentDescription
+                    KeyNavigation.priority: KeyNavigation.BeforeItem
+
+                    Label {
+                        text: "Summary"
+                        opacity: 0.5
+                        visible: parent.length == 0
+                    }
+
+                    onTextChanged: app.commenting(
+                        commentSummary.text,
+                        commentDescription.text
+                    );
+                }
+
+                AwesomeButton {
+                    name: "arrows-alt"
+                    Layout.fillHeight: true
+                    onClicked: root.isMaximised = root.isMaximised ? false : true
+                }
+            }
+
+        }
+
+        View {
+            radius: 3
+            elevation: -1
+            Layout.fillHeight: true
+            Layout.fillWidth: true
+
+            TextEdit {
+                id: commentDescription
+                anchors.fill: parent
+                anchors.margins: 5
+                color: "white"
+                selectionColor: "#222"
+                selectByMouse: true
+                readOnly: root.readOnly
+                wrapMode: TextEdit.WordWrap
+                clip: true
+
+                Label {
+                    text: "Description"
+                    opacity: 0.5
+                    visible: parent.length == 0
+                }
+
+                font.family: "Open Sans"
+                font.weight: Font.Normal
+
+                KeyNavigation.backtab: commentSummary
+                KeyNavigation.priority: KeyNavigation.BeforeItem
+
+                onTextChanged: app.commenting(
+                    commentSummary.text,
+                    commentDescription.text
+                );
+            }
+        }
+    }
+}

--- a/pyblish_qml/qml/Footer.qml
+++ b/pyblish_qml/qml/Footer.qml
@@ -17,6 +17,7 @@ View {
     signal stop
     signal reset
     signal save
+    signal comment
 
     width: 200
     height: 40
@@ -37,6 +38,19 @@ View {
         }
 
         spacing: 3
+
+        AwesomeButton {
+            elevation: 1
+
+            size: 25
+            iconSize: 14
+
+            tooltip: visible ? "Comment.." : ""
+
+            name: app.hasComment ? "comment" : "comment-o"
+            onClicked: footer.comment()
+            visible: mode == 0 ? true : false
+        }
 
         AwesomeButton {
             elevation: 1

--- a/pyblish_qml/qml/Overview.qml
+++ b/pyblish_qml/qml/Overview.qml
@@ -1,4 +1,6 @@
 import QtQuick 2.3
+import QtQuick.Layouts 1.1
+
 import Pyblish 0.1
 import Pyblish.ListItems 0.1
 
@@ -61,7 +63,7 @@ Item {
         id: tabView
 
         anchors.top: tabBar.bottom
-        anchors.bottom: footer.top
+        anchors.bottom: commentBox.top
         anchors.horizontalCenter: parent.horizontalCenter
         anchors.margins: tabView.margins
         anchors.bottomMargin: 0
@@ -173,6 +175,20 @@ Item {
         }
     }
 
+    CommentBox {
+        id: commentBox
+
+        // Enable editing only when the GUI is not busy with something else
+        readOnly: overview.state != ""
+
+        anchors {
+            bottom: footer.top
+            left: parent.left
+            right: parent.right
+        }
+
+        height: isMaximised ? parent.height - footer.height : isUp ? 150 : 0
+    }
 
     Footer {
         id: footer
@@ -189,6 +205,7 @@ Item {
         onReset: app.reset()
         onStop: app.stop()
         onSave: app.save()
+        onComment: commentBox.height > 75 ? commentBox.down() : commentBox.up()
     }
 
     Connections {
@@ -196,6 +213,12 @@ Item {
 
         onError: setMessage(message)
         onInfo: setMessage(message)
+
+        onFirstRun: {
+            app.commentEnabled ? commentBox.up() : null
+            commentBox.summary = app.summary()
+            commentBox.description = app.description()
+        }
 
         onStateChanged: {
             if (state == "ready") {

--- a/pyblish_qml/qml/Overview.qml
+++ b/pyblish_qml/qml/Overview.qml
@@ -185,6 +185,7 @@ Item {
             bottom: footer.top
             left: parent.left
             right: parent.right
+            top: (isMaximised && height == parent.height - footer.height) ? tabBar.top : undefined
         }
 
         height: isMaximised ? parent.height - footer.height : isUp ? 150 : 0

--- a/pyblish_qml/qml/delegates/DocumentationDelegate.qml
+++ b/pyblish_qml/qml/delegates/DocumentationDelegate.qml
@@ -9,6 +9,8 @@ BaseGroupDelegate {
         TextArea {
             id: textArea
 
+            font.family: "consolas"
+
             anchors.fill: parent
             anchors.margins: 10
             text: modelData.item.doc || "No documentation"

--- a/pyblish_qml/version.py
+++ b/pyblish_qml/version.py
@@ -1,7 +1,7 @@
 
 VERSION_MAJOR = 1
-VERSION_MINOR = 0
-VERSION_PATCH = 4
+VERSION_MINOR = 1
+VERSION_PATCH = 0
 
 version_info = (VERSION_MAJOR, VERSION_MINOR, VERSION_PATCH)
 version = '%i.%i.%i' % version_info


### PR DESCRIPTION
This PR enables the user to include a comment with his publish.

![comment_basics](https://cloud.githubusercontent.com/assets/2152766/26346827/6358446a-3f9f-11e7-8d23-4b5694db97b8.gif)

Implements #9.

**Format**

Comments made via the editor is stored in the `comment` data member of the `context`, as a single block of text.

```python
context.data["comment"] = "Summary goes here\nDescription goes here, on a new line"
```

This is similar to comments on Git commits, the first line being dedicated to a short "summary" of your overall commit, with an (optional) longer description.

You can just add a summary, just add a description, or both. The first line always results in the first line of your comment.

**Features**

- Automatically show comment on presence of `context.data["comment"]`
- Remember comment across resets
- Dedicated signal `commented` for optional data persistence
- Maximisable, type out your excellent comment in fullscreen
- Comment template, provide users with a starting point of guidelines for their comment.

![comment_fullscreen](https://cloud.githubusercontent.com/assets/2152766/26346904/aa171e76-3f9f-11e7-978e-4779c0172cb6.gif)

![comment_persistence](https://cloud.githubusercontent.com/assets/2152766/26346908/ac6005c6-3f9f-11e7-9a9a-6938d32482d7.gif)
**Signal**

A signal is emitted when entering a comment, so as to support data persistence, e.g. in Maya or on disk.

```python
from pyblish import api

def persist(comment):
   # write to disk here

api.register_callback("commented", persist)
```

The comment can then be read via e.g. a Collector into the Context which would then become visible in the GUI.

```python
from pyblish import api

class CollectComment(api.ContextPlugin):
  order = api.CollectorOrder

  def process(self, context):
    context.data["comment"] = # read from disk here
```
