### PR TITLE
Set the context label and window title, if not already set externally.

### DIFF
--- a/pyblish_qml/host.py
+++ b/pyblish_qml/host.py
@@ -226,9 +226,10 @@ def _install_maya():
     app = QtWidgets.QApplication.instance()
     app.aboutToQuit.connect(_on_application_quit)
 
-    # Configure GUI
-    settings.ContextLabel = "Maya"
-    settings.WindowTitle = "Pyblish (Maya)"
+    if settings.ContextLabel == "Context":
+        settings.ContextLabel = "Maya"
+    if settings.WindowTitle == "Pyblish":
+        settings.WindowTitle = "Pyblish (Maya)"
 
 
 def _install_houdini():
@@ -245,8 +246,10 @@ def _install_houdini():
     app = QtWidgets.QApplication.instance()
     app.aboutToQuit.connect(_on_application_quit)
 
-    settings.ContextLabel = "Houdini"
-    settings.WindowTitle = "Pyblish (Houdini)"
+    if settings.ContextLabel == "Context":
+        settings.ContextLabel = "Houdini"
+    if settings.WindowTitle == "Pyblish":
+        settings.WindowTitle = "Pyblish (Houdini)"
 
 
 def _install_nuke():
@@ -266,8 +269,10 @@ def _install_nuke():
     app = QtWidgets.QApplication.instance()
     app.aboutToQuit.connect(_on_application_quit)
 
-    settings.ContextLabel = "Nuke"
-    settings.WindowTitle = "Pyblish (Nuke)"
+    if settings.ContextLabel == "Context":
+        settings.ContextLabel = "Nuke"
+    if settings.WindowTitle == "Pyblish":
+        settings.WindowTitle = "Pyblish (Nuke)"
 
 
 def _install_hiero():
@@ -288,8 +293,10 @@ def _install_hiero():
     app = QtWidgets.QApplication.instance()
     app.aboutToQuit.connect(_on_application_quit)
 
-    settings.ContextLabel = "Hiero"
-    settings.WindowTitle = "Pyblish (Hiero)"
+    if settings.ContextLabel == "Context":
+        settings.ContextLabel = "Hiero"
+    if settings.WindowTitle == "Pyblish":
+        settings.WindowTitle = "Pyblish (Hiero)"
 
 
 class Splash(QtWidgets.QWidget):

--- a/pyblish_qml/host.py
+++ b/pyblish_qml/host.py
@@ -226,9 +226,9 @@ def _install_maya():
     app = QtWidgets.QApplication.instance()
     app.aboutToQuit.connect(_on_application_quit)
 
-    if settings.ContextLabel == "Context":
+    if settings.ContextLabel == settings.ContextLabelDefault:
         settings.ContextLabel = "Maya"
-    if settings.WindowTitle == "Pyblish":
+    if settings.WindowTitle == settings.WindowTitleDefault:
         settings.WindowTitle = "Pyblish (Maya)"
 
 
@@ -246,9 +246,9 @@ def _install_houdini():
     app = QtWidgets.QApplication.instance()
     app.aboutToQuit.connect(_on_application_quit)
 
-    if settings.ContextLabel == "Context":
+    if settings.ContextLabel == settings.ContextLabelDefault:
         settings.ContextLabel = "Houdini"
-    if settings.WindowTitle == "Pyblish":
+    if settings.WindowTitle == settings.WindowTitleDefault:
         settings.WindowTitle = "Pyblish (Houdini)"
 
 
@@ -269,9 +269,9 @@ def _install_nuke():
     app = QtWidgets.QApplication.instance()
     app.aboutToQuit.connect(_on_application_quit)
 
-    if settings.ContextLabel == "Context":
+    if settings.ContextLabel == settings.ContextLabelDefault:
         settings.ContextLabel = "Nuke"
-    if settings.WindowTitle == "Pyblish":
+    if settings.WindowTitle == settings.WindowTitleDefault:
         settings.WindowTitle = "Pyblish (Nuke)"
 
 
@@ -293,9 +293,9 @@ def _install_hiero():
     app = QtWidgets.QApplication.instance()
     app.aboutToQuit.connect(_on_application_quit)
 
-    if settings.ContextLabel == "Context":
+    if settings.ContextLabel == settings.ContextLabelDefault:
         settings.ContextLabel = "Hiero"
-    if settings.WindowTitle == "Pyblish":
+    if settings.WindowTitle == settings.WindowTitleDefault:
         settings.WindowTitle = "Pyblish (Hiero)"
 
 

--- a/pyblish_qml/settings.py
+++ b/pyblish_qml/settings.py
@@ -2,8 +2,8 @@ import sys
 
 # User-editable settings
 
-ContextLabel = "Context"
-WindowTitle = "Pyblish"
+ContextLabel = ContextLabelDefault = "Context"
+WindowTitle = WindowTitleDefault = "Pyblish"
 WindowSize = (430, 600)
 WindowPosition = (100, 100)
 HeartbeatInterval = 60


### PR DESCRIPTION
Currently you can't set the context label or window title on startup of the applications.