### PR TITLE
Support Pyblish Standalone

### DIFF
--- a/pyblish_qml/host.py
+++ b/pyblish_qml/host.py
@@ -298,12 +298,12 @@ def _install_standalone():
     import pyblish_standalone
 
     def threaded_wrapper(func, *args, **kwargs):
-        return func(args, kwargs)
+        return func(*args, **kwargs)
 
     sys.stdout.write("Setting up Pyblish QML in Pyblish Standalone\n")
     register_dispatch_wrapper(threaded_wrapper)
 
-    app = QtWidgets.QApplication(sys.argv)
+    app = QtWidgets.QApplication.instance()
     app.aboutToQuit.connect(_on_application_quit)
 
     settings.ContextLabel = "Standalone"

--- a/pyblish_qml/host.py
+++ b/pyblish_qml/host.py
@@ -188,7 +188,8 @@ def install_host():
     for install in (_install_maya,
                     _install_houdini,
                     _install_nuke,
-                    _install_hiero):
+                    _install_hiero,
+                    _install_standalone):
         try:
             install()
         except ImportError:
@@ -290,6 +291,23 @@ def _install_hiero():
 
     settings.ContextLabel = "Hiero"
     settings.WindowTitle = "Pyblish (Hiero)"
+
+
+def _install_standalone():
+    """Helper function to Pyblish Standalone support"""
+    import pyblish_standalone
+
+    def threaded_wrapper(func, *args, **kwargs):
+        return func(args, kwargs)
+
+    sys.stdout.write("Setting up Pyblish QML in Pyblish Standalone\n")
+    register_dispatch_wrapper(threaded_wrapper)
+
+    app = QtWidgets.QApplication(sys.argv)
+    app.aboutToQuit.connect(_on_application_quit)
+
+    settings.ContextLabel = "Standalone"
+    settings.WindowTitle = "Pyblish (Standalone)"
 
 
 class Splash(QtWidgets.QWidget):


### PR DESCRIPTION
This is not working code, but I thought it would be best to start the discussion about whys and hows like this.

This is the current output, resulting in no interface:
```
$ python -m pyblish_standalone --register-gui pyblish_qml
Found gui: <module 'pyblish_qml' from 'c:\users\tje\documents\conda-git-deployment\repositories\tgbvfx-environment\pyblish-qml\pyblish_qml\__init__.pyc'>
Setting up Pyblish QML in Pyblish Standalone
$
```
I'm probably missing an ```app.exec_()```, but I don't know where to put it as putting it in ```_install_standalone``` makes the execution stop after ```Setting up Pyblish QML in Pyblish Standalone``` without an gui.

I'm also unsure of how the ```threaded_wrapper``` should work. Maybe it needs to be run in a separate thread?