### PR TITLE
Emit close signal

### DIFF
--- a/pyblish_qml/app.py
+++ b/pyblish_qml/app.py
@@ -39,15 +39,14 @@ class Window(QtQuick.QQuickView):
             modifiers = self.parent.queryKeyboardModifiers()
             shift_pressed = QtCore.Qt.ShiftModifier & modifiers
             states = self.parent.controller.states
-            close_signal = "pyblishQmlClose"
 
             if shift_pressed:
                 print("Force quitted..")
-                self.parent.controller.host.emit(close_signal)
+                self.parent.controller.host.emit("pyblishQmlCloseForced")
                 event.accept()
 
             elif any(state in states for state in ("ready", "finished")):
-                self.parent.controller.host.emit(close_signal)
+                self.parent.controller.host.emit("pyblishQmlClose")
                 event.accept()
 
             else:

--- a/pyblish_qml/app.py
+++ b/pyblish_qml/app.py
@@ -39,12 +39,15 @@ class Window(QtQuick.QQuickView):
             modifiers = self.parent.queryKeyboardModifiers()
             shift_pressed = QtCore.Qt.ShiftModifier & modifiers
             states = self.parent.controller.states
+            close_signal = "pyblishQmlClose"
 
             if shift_pressed:
                 print("Force quitted..")
+                self.parent.controller.host.emit(close_signal)
                 event.accept()
 
             elif any(state in states for state in ("ready", "finished")):
+                self.parent.controller.host.emit(close_signal)
                 event.accept()
 
             else:

--- a/pyblish_qml/ipc/mocking.py
+++ b/pyblish_qml/ipc/mocking.py
@@ -654,3 +654,11 @@ plugins = [
 ]
 
 pyblish.api.sort_plugins(plugins)
+
+
+# Callbacks
+def close_callback():
+    print "Custom callback when closing..."
+
+
+pyblish.api.register_callback("pyblishQmlClose", close_callback)

--- a/pyblish_qml/ipc/mocking.py
+++ b/pyblish_qml/ipc/mocking.py
@@ -661,4 +661,9 @@ def close_callback():
     print("Custom callback when closing...")
 
 
+def close_forced_callback():
+    print("Custom callback when closing forcibly...")
+
+
 pyblish.api.register_callback("pyblishQmlClose", close_callback)
+pyblish.api.register_callback("pyblishQmlCloseForced", close_forced_callback)

--- a/pyblish_qml/ipc/mocking.py
+++ b/pyblish_qml/ipc/mocking.py
@@ -658,7 +658,7 @@ pyblish.api.sort_plugins(plugins)
 
 # Callbacks
 def close_callback():
-    print "Custom callback when closing..."
+    print("Custom callback when closing...")
 
 
 pyblish.api.register_callback("pyblishQmlClose", close_callback)


### PR DESCRIPTION
**Motivation**

This is to add the ability to execute code when the pyblish-qml window is closed.

**Implementation**

Maybe we should have a dedicated "pyblishQmlCloseForced" event emitted as well when closing forcibly?

Also I would like to write a test for the signal as well, but I find it hard to write test for pyblish-qml because I don't have access to Docker. Maybe we could have a ```run_tests.py``` for local testing?