### PR TITLE
Targets workflow.

### DIFF
--- a/pyblish_qml/__init__.py
+++ b/pyblish_qml/__init__.py
@@ -5,9 +5,9 @@ from .version import (
 )
 
 
-def show(parent=None):
+def show(parent=None, targets=[]):
     from . import host
-    return host.show(parent)
+    return host.show(parent, targets)
 
 
 _state = {}

--- a/pyblish_qml/__main__.py
+++ b/pyblish_qml/__main__.py
@@ -11,8 +11,15 @@ def cli():
     parser.add_argument("--demo", action="store_true")
     parser.add_argument("--aschild", action="store_true",
                         help="Run as child of another process")
+    parser.add_argument(
+        "--targets",
+        nargs="*",
+        help="Targets to run plugins against."
+    )
 
     kwargs = parser.parse_args()
+    if kwargs.targets is None:
+        kwargs.targets = []
 
     return app.main(**kwargs.__dict__)
 

--- a/pyblish_qml/app.py
+++ b/pyblish_qml/app.py
@@ -68,7 +68,7 @@ class Application(QtGui.QGuiApplication):
     hidden = QtCore.pyqtSignal()
     quitted = QtCore.pyqtSignal()
 
-    def __init__(self, source):
+    def __init__(self, source, targets=[]):
         super(Application, self).__init__(sys.argv)
 
         self.setWindowIcon(QtGui.QIcon(ICON_PATH))
@@ -80,7 +80,7 @@ class Application(QtGui.QGuiApplication):
         engine.addImportPath(QML_IMPORT_DIR)
 
         host = ipc.client.Proxy()
-        controller = control.Controller(host)
+        controller = control.Controller(host, targets=targets)
         controller.finished.connect(lambda: window.alert(0))
 
         context = engine.rootContext()
@@ -224,7 +224,7 @@ class Application(QtGui.QGuiApplication):
         thread.start()
 
 
-def main(demo=False, aschild=False):
+def main(demo=False, aschild=False, targets=[]):
     """Start the Qt-runtime and show the window
 
     Arguments:
@@ -235,7 +235,7 @@ def main(demo=False, aschild=False):
     if aschild:
         print("Starting pyblish-qml")
         compat.main()
-        app = Application(APP_PATH)
+        app = Application(APP_PATH, targets)
         app.listen()
 
         print("Done, don't forget to call `show()`")
@@ -244,7 +244,7 @@ def main(demo=False, aschild=False):
     else:
         print("Starting pyblish-qml server..")
         service = ipc.service.MockService() if demo else ipc.service.Service()
-        server = ipc.server.Server(service)
+        server = ipc.server.Server(service, targets=targets)
 
         proxy = ipc.server.Proxy(server)
         proxy.show(settings.to_dict())

--- a/pyblish_qml/control.py
+++ b/pyblish_qml/control.py
@@ -65,12 +65,6 @@ class Controller(QtCore.QObject):
         self.host = host
 
         self.targets = targets
-        # If no targets are passed to pyblish-qml, we assume that we want all
-        # targets. This is to facilitate getting all plugins on
-        # pyblish_qml.show().
-        if not self.targets:
-            self.targets = ["default"]
-        print("Targets: {0}".format(", ".join(self.targets)))
 
         self.data = {
             "models": {

--- a/pyblish_qml/control.py
+++ b/pyblish_qml/control.py
@@ -58,11 +58,19 @@ class Controller(QtCore.QObject):
     resultModel = qtproperty(lambda self: self.data["models"]["result"])
     resultProxy = qtproperty(lambda self: self.data["proxies"]["result"])
 
-    def __init__(self, host, parent=None):
+    def __init__(self, host, parent=None, targets=[]):
         super(Controller, self).__init__(parent)
 
         # Connection to host
         self.host = host
+
+        self.targets = targets
+        # If no targets are passed to pyblish-qml, we assume that we want all
+        # targets. This is to facilitate getting all plugins on
+        # pyblish_qml.show().
+        if not self.targets:
+            self.targets = ["default"]
+        print("Targets: {0}".format(", ".join(self.targets)))
 
         self.data = {
             "models": {
@@ -758,6 +766,8 @@ class Controller(QtCore.QObject):
         def on_discover(plugins, context):
             collectors = list()
 
+            plugins = pyblish.api.plugins_by_targets(plugins, self.targets)
+
             for plugin in plugins:
                 self.data["models"]["item"].add_plugin(plugin.to_json())
 
@@ -778,6 +788,7 @@ class Controller(QtCore.QObject):
 
         def on_context(context):
             context.data["pyblishQmlVersion"] = version
+            context.data["targets"] = ", ".join(self.targets)
 
             self.data["models"]["item"].add_context(context.to_json())
             self.data["models"]["result"].add_context(context.to_json())

--- a/pyblish_qml/host.py
+++ b/pyblish_qml/host.py
@@ -66,7 +66,7 @@ def uninstall():
     sys.stdout.write("Pyblish QML shutdown successful.\n")
 
 
-def show(parent=None):
+def show(parent=None, targets=[]):
     """Attempt to show GUI
 
     Requires install() to have been run first, and
@@ -109,7 +109,7 @@ def show(parent=None):
 
     try:
         service = ipc.service.Service()
-        server = ipc.server.Server(service)
+        server = ipc.server.Server(service, targets=targets)
     except Exception:
         # If for some reason, the GUI fails to show.
         traceback.print_exc()

--- a/pyblish_qml/ipc/formatting.py
+++ b/pyblish_qml/ipc/formatting.py
@@ -267,6 +267,7 @@ def format_plugin(plugin):
         "optional": plugin.optional,
         "hosts": plugin.hosts,
         "families": plugin.families,
+        "targets": plugin.targets,
         "doc": inspect.getdoc(plugin),
         "active": plugin.active,
         "match": plugin.match,

--- a/pyblish_qml/ipc/mocking.py
+++ b/pyblish_qml/ipc/mocking.py
@@ -538,6 +538,24 @@ class InactiveInstanceCollectorPlugin(pyblish.api.InstancePlugin):
         raise TypeError("I shouldn't have run in the first place")
 
 
+class TargetedCollector(pyblish.api.ContextPlugin):
+    """Target collector to "studio" target."""
+    order = pyblish.api.CollectorOrder
+    targets = ["studio"]
+
+    def process(self, context):
+        pass
+
+
+class TargetedValidator(pyblish.api.ContextPlugin):
+    """Target validator to "studio" target."""
+    order = pyblish.api.ValidatorOrder
+    targets = ["studio"]
+
+    def process(self, context):
+        pass
+
+
 instances = [
     {
         "name": "Peter01",
@@ -650,7 +668,10 @@ plugins = [
     LongRunningValidator,
 
     RearrangingPlugin,
-    InactiveInstanceCollectorPlugin
+    InactiveInstanceCollectorPlugin,
+
+    TargetedCollector,
+    TargetedValidator
 ]
 
 pyblish.api.sort_plugins(plugins)

--- a/pyblish_qml/ipc/schema/plugin.json
+++ b/pyblish_qml/ipc/schema/plugin.json
@@ -19,6 +19,10 @@
             "type": "array",
             "items": {"type": "string"}
         },
+        "targets": {
+            "type": "array",
+            "items": {"type": "string"}
+        },
         "order": {
             "type": "number"
         },

--- a/pyblish_qml/ipc/server.py
+++ b/pyblish_qml/ipc/server.py
@@ -73,7 +73,7 @@ class Server(object):
 
     """
 
-    def __init__(self, service, python=None, pyqt5=None):
+    def __init__(self, service, python=None, pyqt5=None, targets=[]):
         super(Server, self).__init__()
         self.service = service
         self.listening = False
@@ -148,6 +148,10 @@ class Server(object):
             # This will prevent an embedded Python
             # from opening an external terminal window.
             kwargs["creationflags"] = CREATE_NO_WINDOW
+
+        if targets:
+            kwargs["args"].append("--targets")
+            kwargs["args"].extend(targets)
 
         self.popen = subprocess.Popen(**kwargs)
         self.listen()

--- a/pyblish_qml/ipc/server.py
+++ b/pyblish_qml/ipc/server.py
@@ -149,9 +149,16 @@ class Server(object):
             # from opening an external terminal window.
             kwargs["creationflags"] = CREATE_NO_WINDOW
 
-        if targets:
-            kwargs["args"].append("--targets")
-            kwargs["args"].extend(targets)
+        # If no targets are passed to pyblish-qml, we assume that we want the
+        # default target and the registered targets. This is to facilitate
+        # getting all plugins on pyblish_qml.show().
+        import pyblish.api
+        if not targets:
+            targets = ["default"] + pyblish.api.registered_targets()
+        print("Targets: {0}".format(", ".join(targets)))
+
+        kwargs["args"].append("--targets")
+        kwargs["args"].extend(targets)
 
         self.popen = subprocess.Popen(**kwargs)
         self.listen()

--- a/pyblish_qml/qml/delegates/ContextDelegate.qml
+++ b/pyblish_qml/qml/delegates/ContextDelegate.qml
@@ -44,6 +44,10 @@ BaseDelegate {
                     "value": object.host
                 },
                 {
+                    "key": "Targets",
+                    "value": object.targets
+                },
+                {
                     "key": "Connected",
                     "value": Date(Date.parse(object.connectTime))
                 }]

--- a/pyblish_qml/version.py
+++ b/pyblish_qml/version.py
@@ -1,7 +1,7 @@
 
 VERSION_MAJOR = 1
-VERSION_MINOR = 3
-VERSION_PATCH = 1
+VERSION_MINOR = 4
+VERSION_PATCH = 0
 
 version_info = (VERSION_MAJOR, VERSION_MINOR, VERSION_PATCH)
 version = '%i.%i.%i' % version_info


### PR DESCRIPTION
**Motivation**

This PR is to facilitate the targets workflow that was introduced in https://github.com/pyblish/pyblish-base/releases/tag/1.5.0.

**Implementation**

The implementation for pyblish-qml is done so you can exclusively target plugins. For a demonstration you can execute:

```bash
$ python -m pyblish_qml --demo --targets studio
```

This will only load two plugins that are targeted directly for ```studio```.
To get all plugins you can target both ```default``` and ```studio```:

```bash
$ python -m pyblish_qml --demo --targets default studio
```

You can also specify the targets when showing pyblish-qml from a host:

```python
import pyblish_qml
pyblish_qml.show(targets=["studio"])
```

Because the matching is using ```pyblish.api.plugins_by_targets``` its important to get https://github.com/pyblish/pyblish-base/pull/321 merged first.

Lastly I'm not sure whether there is better way than passing the ```targets``` argument all the way through to the controller?