### PR TITLE
Fix #249 Mangled comment

### DIFF
--- a/pyblish_qml/control.py
+++ b/pyblish_qml/control.py
@@ -601,6 +601,8 @@ class Controller(QtCore.QObject):
         """The user is entering a comment"""
 
         def update():
+            self.data.update({"comment": (summary, description)})
+
             comment = "\n".join(
                 entry for entry in self.data["comment"]
                 if entry
@@ -608,7 +610,6 @@ class Controller(QtCore.QObject):
 
             context = self.host.cached_context
             context.data["comment"] = comment
-            self.data.update({"comment": (summary, description)})
 
             # Notify subscribers of the comment
             self.host.update(key="comment", value=comment)

--- a/pyblish_qml/control.py
+++ b/pyblish_qml/control.py
@@ -42,9 +42,7 @@ class Controller(QtCore.QObject):
     finished = QtCore.pyqtSignal()
     initialised = QtCore.pyqtSignal()
     commented = QtCore.pyqtSignal()
-    commenting = QtCore.pyqtSignal(str,
-                                   str,
-                                   arguments=["summary", "description"])
+    commenting = QtCore.pyqtSignal(str, arguments=["comment"])
 
     state_changed = QtCore.pyqtSignal(str, arguments=["state"])
 
@@ -69,7 +67,7 @@ class Controller(QtCore.QObject):
                 "item": models.ItemModel(),
                 "result": models.ResultModel(),
             },
-            "comment": [],
+            "comment": "",
             "firstRun": True
         }
 
@@ -264,20 +262,9 @@ class Controller(QtCore.QObject):
         return machine
 
     @QtCore.pyqtSlot(result=str)
-    def summary(self):
+    def comment(self):
         """Return first line of comment"""
-        try:
-            return self.data["comment"][0]
-        except IndexError:
-            return None
-
-    @QtCore.pyqtSlot(result=str)
-    def description(self):
-        """Return subseqent lines of comment (if any)"""
-        try:
-            return self.data["comment"][1]
-        except IndexError:
-            return None
+        return self.data["comment"]
 
     @QtCore.pyqtProperty(str, notify=state_changed)
     def state(self):
@@ -285,7 +272,7 @@ class Controller(QtCore.QObject):
 
     @QtCore.pyqtProperty(bool, notify=commented)
     def hasComment(self):
-        return any(self.data["comment"])
+        return True if self.data["comment"] else False
 
     @QtCore.pyqtProperty(bool, constant=True)
     def commentEnabled(self):
@@ -597,19 +584,13 @@ class Controller(QtCore.QObject):
 
     # Event handlers
 
-    def on_commenting(self, summary, description):
+    def on_commenting(self, comment):
         """The user is entering a comment"""
 
         def update():
-            self.data.update({"comment": (summary, description)})
-
-            comment = "\n".join(
-                entry for entry in self.data["comment"]
-                if entry
-            )
-
             context = self.host.cached_context
             context.data["comment"] = comment
+            self.data["comment"] = comment
 
             # Notify subscribers of the comment
             self.host.update(key="comment", value=comment)
@@ -739,11 +720,8 @@ class Controller(QtCore.QObject):
                 self.host.cached_context.data["comment"] = comment
             else:
                 print("No local comment, reading from context..")
-                summary, description = (self.host.cached_context.data.get(
-                    "comment", "").split("\n", 1) + [None]
-                )[:2]
-
-                self.data["comment"] = [summary, description]
+                comment = self.host.cached_context.data.get("comment", "")
+                self.data["comment"] = comment
 
             if self.data["firstRun"]:
                 self.firstRun.emit()

--- a/pyblish_qml/ipc/mocking.py
+++ b/pyblish_qml/ipc/mocking.py
@@ -538,6 +538,14 @@ class InactiveInstanceCollectorPlugin(pyblish.api.InstancePlugin):
         raise TypeError("I shouldn't have run in the first place")
 
 
+class CommentPlugin(pyblish.api.ContextPlugin):
+    """Display whatever comment was entered"""
+    order = pyblish.api.ValidatorOrder
+
+    def process(self, context):
+        self.log.info(context.data.get("comment", "No comment"))
+
+
 instances = [
     {
         "name": "Peter01",
@@ -650,7 +658,9 @@ plugins = [
     LongRunningValidator,
 
     RearrangingPlugin,
-    InactiveInstanceCollectorPlugin
+    InactiveInstanceCollectorPlugin,
+
+    CommentPlugin,
 ]
 
 pyblish.api.sort_plugins(plugins)

--- a/pyblish_qml/qml/CommentBox.qml
+++ b/pyblish_qml/qml/CommentBox.qml
@@ -13,8 +13,7 @@ Rectangle {
     property bool isUp
     property bool isMaximised
 
-    property alias summary: commentSummary.text
-    property alias description: commentDescription.text
+    property alias text: textBox.text
 
     property var readOnly: false
 
@@ -27,7 +26,7 @@ Rectangle {
 
     function up() {
         isUp = true
-        commentSummary.forceActiveFocus()
+        textBox.forceActiveFocus()
     }
 
     function down() {
@@ -39,91 +38,39 @@ Rectangle {
         isUp ? down() : up()
     }
 
-    ColumnLayout {
+    View {
+        radius: 3
+        elevation: -1
         anchors.fill: parent
         anchors.margins: 5
+        Layout.fillHeight: true
+        Layout.fillWidth: true
 
-        View {
-            radius: 3
-            height: 27
-            elevation: -1
-            Layout.fillWidth: true
+        TextEdit {
+            id: textBox
+            anchors.fill: parent
+            anchors.margins: 5
+            color: "white"
+            selectionColor: "#222"
+            selectByMouse: true
+            readOnly: root.readOnly
+            wrapMode: TextEdit.WordWrap
+            clip: true
 
-            RowLayout {
-                anchors.fill: parent
-                anchors.margins: 5
-                
-                TextInput {
-                    id: commentSummary
-                    Layout.fillWidth: true
-                    Layout.fillHeight: true
-                    color: "white"
-                    selectionColor: "#222"
-                    readOnly: root.readOnly
-                    selectByMouse: true
-                    clip: true
-
-                    font.family: "Open Sans"
-                    font.weight: Font.Normal
-
-                    KeyNavigation.tab: commentDescription
-                    KeyNavigation.backtab: commentDescription
-                    KeyNavigation.priority: KeyNavigation.BeforeItem
-
-                    Label {
-                        text: "Summary"
-                        opacity: 0.5
-                        visible: parent.length == 0
-                    }
-
-                    onTextChanged: app.commenting(
-                        commentSummary.text,
-                        commentDescription.text
-                    );
-                }
-
-                AwesomeButton {
-                    name: "arrows-alt"
-                    Layout.fillHeight: true
-                    onClicked: root.isMaximised = root.isMaximised ? false : true
-                }
+            Label {
+                text: "Comment"
+                opacity: 0.5
+                visible: parent.length == 0
             }
 
-        }
+            font.family: "Open Sans"
+            font.weight: Font.Normal
 
-        View {
-            radius: 3
-            elevation: -1
-            Layout.fillHeight: true
-            Layout.fillWidth: true
+            KeyNavigation.priority: KeyNavigation.BeforeItem
 
-            TextEdit {
-                id: commentDescription
-                anchors.fill: parent
-                anchors.margins: 5
-                color: "white"
-                selectionColor: "#222"
-                selectByMouse: true
-                readOnly: root.readOnly
-                wrapMode: TextEdit.WordWrap
-                clip: true
-
-                Label {
-                    text: "Description"
-                    opacity: 0.5
-                    visible: parent.length == 0
-                }
-
-                font.family: "Open Sans"
-                font.weight: Font.Normal
-
-                KeyNavigation.backtab: commentSummary
-                KeyNavigation.priority: KeyNavigation.BeforeItem
-
-                onTextChanged: app.commenting(
-                    commentSummary.text,
-                    commentDescription.text
-                );
+            onTextChanged: {
+                app.commenting(text);
+                console.log(text);
             }
         }
     }

--- a/pyblish_qml/qml/CommentBox.qml
+++ b/pyblish_qml/qml/CommentBox.qml
@@ -68,10 +68,7 @@ Rectangle {
 
             KeyNavigation.priority: KeyNavigation.BeforeItem
 
-            onTextChanged: {
-                app.commenting(text);
-                console.log(text);
-            }
+            onTextChanged: app.commenting(text)
         }
     }
 }

--- a/pyblish_qml/qml/Overview.qml
+++ b/pyblish_qml/qml/Overview.qml
@@ -217,8 +217,7 @@ Item {
 
         onFirstRun: {
             app.commentEnabled ? commentBox.up() : null
-            commentBox.summary = app.summary()
-            commentBox.description = app.description()
+            commentBox.text = app.comment()
         }
 
         onStateChanged: {

--- a/pyblish_qml/version.py
+++ b/pyblish_qml/version.py
@@ -1,7 +1,7 @@
 
 VERSION_MAJOR = 1
 VERSION_MINOR = 3
-VERSION_PATCH = 0
+VERSION_PATCH = 1
 
 version_info = (VERSION_MAJOR, VERSION_MINOR, VERSION_PATCH)
 version = '%i.%i.%i' % version_info


### PR DESCRIPTION
Hi Marcus,

This fixes #249 .

https://github.com/pyblish/pyblish-qml/blob/master/pyblish_qml/control.py#L603-L615
```python
    def on_commenting(self, summary, description):

        def update():
            comment = "\n".join( entry for entry in self.data["comment"] if entry)   # <= This and...

            context = self.host.cached_context
            context.data["comment"] = comment
            self.data.update({"comment": (summary, description)})  # <= This line must before `comment` declaration

```

### Cause
* There seems mismatch with updating host's context between updating its content of `self.data`.

### Result
* Host receive previous state of `self.data["comment"]`