### PR TITLE
Added support for publish and validate from within the host app

### DIFF
--- a/pyblish_qml/app.py
+++ b/pyblish_qml/app.py
@@ -70,6 +70,8 @@ class Application(QtGui.QGuiApplication):
     risen = QtCore.pyqtSignal()
     inFocused = QtCore.pyqtSignal()
     outFocused = QtCore.pyqtSignal()
+    published = QtCore.pyqtSignal()
+    validated = QtCore.pyqtSignal()
 
     def __init__(self, source, targets=[]):
         super(Application, self).__init__(sys.argv)
@@ -102,6 +104,8 @@ class Application(QtGui.QGuiApplication):
         self.risen.connect(self.rise)
         self.inFocused.connect(self.inFocus)
         self.outFocused.connect(self.outFocus)
+        self.published.connect(self.publish)
+        self.validated.connect(self.validate)
 
         window.setSource(QtCore.QUrl.fromLocalFile(source))
 
@@ -207,6 +211,14 @@ class Application(QtGui.QGuiApplication):
             previous_flags = self.window.flags()
             self.window.setFlags(previous_flags ^ QtCore.Qt.WindowStaysOnTopHint)
 
+    def publish(self):
+        """Fire up the publish sequence"""
+        self.controller.publish()
+
+    def validate(self):
+        """Fire up the validation sequance"""
+        self.controller.validate()
+
     def listen(self):
         """Listen on incoming messages from host
 
@@ -232,6 +244,8 @@ class Application(QtGui.QGuiApplication):
                     "rise": "risen",
                     "inFocus": "inFocused",
                     "outFocus": "outFocused",
+                    "publish": "published",
+                    "validate": "validated"
                 }.get(payload["name"])
 
                 if not signal:

--- a/pyblish_qml/host.py
+++ b/pyblish_qml/host.py
@@ -126,6 +126,31 @@ def show(parent=None, targets=[]):
 
     return server
 
+def publish():
+    # get existing GUI
+    if _state.get("currentServer"):
+        server = _state["currentServer"]
+        proxy = ipc.server.Proxy(server)
+
+        try:
+            proxy.publish()
+
+        except IOError:
+            # The running instance has already been closed.
+            _state.pop("currentServer")
+
+def validate():
+    # get existing GUI
+    if _state.get("currentServer"):
+        server = _state["currentServer"]
+        proxy = ipc.server.Proxy(server)
+
+        try:
+            proxy.validate()
+
+        except IOError:
+            # The running instance has already been closed.
+            _state.pop("currentServer")
 
 def install_callbacks():
     pyblish.api.register_callback("instanceToggled", _toggle_instance)

--- a/pyblish_qml/ipc/server.py
+++ b/pyblish_qml/ipc/server.py
@@ -55,6 +55,12 @@ class Proxy(object):
         """Forcefully destroy the process"""
         self.popen.kill()
 
+    def publish(self):
+        self._dispatch("publish")
+
+    def validate(self):
+        self._dispatch("validate")
+
     def _dispatch(self, func, args=None):
         data = json.dumps(
             {

--- a/pyblish_qml/version.py
+++ b/pyblish_qml/version.py
@@ -1,7 +1,7 @@
 
 VERSION_MAJOR = 1
 VERSION_MINOR = 4
-VERSION_PATCH = 3
+VERSION_PATCH = 4
 
 version_info = (VERSION_MAJOR, VERSION_MINOR, VERSION_PATCH)
 version = '%i.%i.%i' % version_info


### PR DESCRIPTION
Looking for the best way to call pyblish_qml's window actions, like publish, validate, etc
In pylish_lite, we can simply do:
```
window = pyblish_maya.show()
window.publish() #after validation...
```
After chatting [here ](http://forums.pyblish.com/t/call-pyblish-qml-actions/388 )with @mottosso, 
Here's what i came up with.
Usage:

```
import pyblish_qml.host

pyblish_qml.host.publish()
pyblish_qml.host.validate()
```

