### PR TITLE
Implement pyblish-base/#250

### DIFF
--- a/pyblish_qml/control.py
+++ b/pyblish_qml/control.py
@@ -692,12 +692,12 @@ class Controller(QtCore.QObject):
                                                                   plugin)
                     plugin.compatibleInstances = list(i.id for i in instances)
                 else:
-             
 
                     # When filtering to families at least a single instance 
                     # with that family must be available for ContextPlugin
-                    if ("*" in plugin.families or 
-                          pyblish.logic.instances_by_plugin(context, plugin)):
+                    has_wildcard = "*" in plugin.families
+                    has_one = pyblish.logic.instances_by_plugin(context, plugin) != []
+                    if has_wildcard or has_one:
                         plugin.compatibleInstances = [context.id]
 
             self.data["models"]["item"].reorder(context)
@@ -1052,14 +1052,12 @@ def iterator(plugins, context):
                 yield plugin, instance
 
         else:
-        
-     
             # When filtering to families at least a single instance with
             # that family must be active in the current publish
-            if "*" not in plugin.families:
-                if not any(instance.data.get("publish") is not False 
-                           for instance in instances):
-                    continue
-                    
-        
+            no_wildcard = "*" not in plugin.families
+            no_active_instance = not any(inst.data.get("publish") for inst in instances)
+
+            if no_wildcard and no_active_instance:
+                continue
+
             yield plugin, None

--- a/pyblish_qml/control.py
+++ b/pyblish_qml/control.py
@@ -692,7 +692,13 @@ class Controller(QtCore.QObject):
                                                                   plugin)
                     plugin.compatibleInstances = list(i.id for i in instances)
                 else:
-                    plugin.compatibleInstances = [context.id]
+             
+
+                    # When filtering to families at least a single instance 
+                    # with that family must be available for ContextPlugin
+                    if ("*" in plugin.families or 
+                          pyblish.logic.instances_by_plugin(context, plugin)):
+                        plugin.compatibleInstances = [context.id]
 
             self.data["models"]["item"].reorder(context)
 
@@ -1046,4 +1052,14 @@ def iterator(plugins, context):
                 yield plugin, instance
 
         else:
+        
+     
+            # When filtering to families at least a single instance with
+            # that family must be active in the current publish
+            if "*" not in plugin.families:
+                if not any(instance.data.get("publish") is not False 
+                           for instance in instances):
+                    continue
+                    
+        
             yield plugin, None

--- a/pyblish_qml/control.py
+++ b/pyblish_qml/control.py
@@ -571,6 +571,11 @@ class Controller(QtCore.QObject):
                            new_value=new_value,
                            old_value=old_value)
 
+            # Update the plugin's active state so it processes correctly (#218)
+            plugin = next(plugin for plugin in self.host.cached_discover if
+                          plugin.id == item.id)
+            plugin.active = new_value
+
         if item.itemType == 'instance':
             self.host.emit("instanceToggled",
                            instance=item.id,


### PR DESCRIPTION
Implement the same functionality for QML as for base regarding: https://github.com/pyblish/pyblish-base/issues/250

This should work with PR: https://github.com/pyblish/pyblish-base/pull/325

---

Note: Somehow when toggling off an instance of family `a` it will still show the ContextPlugins that are filtered to family a, but it will not run them. How to visually hide them I have no clue, but aside from cosmetics it is working.