### PR TITLE
fix instance Warning state behavior in GUI

### DIFF
--- a/pyblish_qml/models.py
+++ b/pyblish_qml/models.py
@@ -466,7 +466,7 @@ class ItemModel(AbstractModel):
                 item.succeeded = True
                 item.amountPassed += 1
 
-            if not (item.hasWarning and not item.hasError):
+            if item.hasError:
                 item.hasWarning = False
 
             item.duration += result["duration"]

--- a/pyblish_qml/models.py
+++ b/pyblish_qml/models.py
@@ -453,7 +453,7 @@ class ItemModel(AbstractModel):
             item.isProcessing = False
             item.currentProgress = 1
             item.processed = True
-            item.hasWarning |= any([
+            item.hasWarning = item.hasWarning or any([
                 record["levelno"] == logging.WARNING
                 for record in result["records"]
             ])

--- a/pyblish_qml/models.py
+++ b/pyblish_qml/models.py
@@ -454,7 +454,7 @@ class ItemModel(AbstractModel):
             item.isProcessing = False
             item.currentProgress = 1
             item.processed = True
-            item.hasWarning = item.persistWarning or any([
+            item.hasWarning |= any([
                 record["levelno"] == logging.WARNING
                 for record in result["records"]
             ])

--- a/pyblish_qml/models.py
+++ b/pyblish_qml/models.py
@@ -466,9 +466,6 @@ class ItemModel(AbstractModel):
                 item.succeeded = True
                 item.amountPassed += 1
 
-            if item.hasError:
-                item.hasWarning = False
-
             item.duration += result["duration"]
             item.finishedAt = time.time()
 

--- a/pyblish_qml/models.py
+++ b/pyblish_qml/models.py
@@ -17,7 +17,6 @@ defaults = {
         "familiesConcatenated": "",
         "isToggled": True,
         "hasWarning": False,
-        "persistWarning": False,
         "hasError": False,
         "actionHasError": False,
         "actionPending": True,
@@ -467,11 +466,8 @@ class ItemModel(AbstractModel):
                 item.succeeded = True
                 item.amountPassed += 1
 
-            if item.hasWarning and not item.hasError:
-                item.persistWarning = True
-            else:
+            if not (item.hasWarning and not item.hasError):
                 item.hasWarning = False
-                item.persistWarning = False
 
             item.duration += result["duration"]
             item.finishedAt = time.time()

--- a/pyblish_qml/models.py
+++ b/pyblish_qml/models.py
@@ -17,6 +17,7 @@ defaults = {
         "familiesConcatenated": "",
         "isToggled": True,
         "hasWarning": False,
+        "persistWarning": False,
         "hasError": False,
         "actionHasError": False,
         "actionPending": True,
@@ -453,7 +454,7 @@ class ItemModel(AbstractModel):
             item.isProcessing = False
             item.currentProgress = 1
             item.processed = True
-            item.hasWarning = any([
+            item.hasWarning = item.persistWarning or any([
                 record["levelno"] == logging.WARNING
                 for record in result["records"]
             ])
@@ -465,6 +466,12 @@ class ItemModel(AbstractModel):
             else:
                 item.succeeded = True
                 item.amountPassed += 1
+
+            if item.hasWarning and not item.hasError:
+                item.persistWarning = True
+            else:
+                item.hasWarning = False
+                item.persistWarning = False
 
             item.duration += result["duration"]
             item.finishedAt = time.time()

--- a/pyblish_qml/qml/List.qml
+++ b/pyblish_qml/qml/List.qml
@@ -30,10 +30,10 @@ ListView {
         status: {
             if (object.isProcessing)
                 return "processing"
-            if (object.hasWarning)
-                return "warning"
             if (object.hasError)
                 return "error"
+            if (object.hasWarning)
+                return "warning"
             if (object.succeeded)
                 return "success"
             return "default"

--- a/pyblish_qml/version.py
+++ b/pyblish_qml/version.py
@@ -1,7 +1,7 @@
 
 VERSION_MAJOR = 1
 VERSION_MINOR = 4
-VERSION_PATCH = 4
+VERSION_PATCH = 5
 
 version_info = (VERSION_MAJOR, VERSION_MINOR, VERSION_PATCH)
 version = '%i.%i.%i' % version_info


### PR DESCRIPTION
Found that instance's warning state only take effect from the last plugin.
* If warning was not emitted by the last plugin, then it will be override by ~~error or *(it should be)*~~ success.

	![](https://i.imgur.com/c9GMmoo.png)

* If warning was emitted by the last plugin, instance's error state will be override.

	![](https://i.imgur.com/Nc2HP3e.png)

---

Thought this should not be a normal ~~instance item~~ log level behavior, I added `persistWarning` into item-model to keep the warning state for instance item, and reset warning state if that instance got error.

![](https://i.imgur.com/6hCkBbX.png)
![](https://i.imgur.com/voh8yWG.png)

---

[Simple test case I used](https://gist.github.com/davidlatwe/37766b311e708a2df988c15852c8fe09)