### PR TITLE
Modal mode

### DIFF
--- a/pyblish_qml/__init__.py
+++ b/pyblish_qml/__init__.py
@@ -5,8 +5,11 @@ from .version import (
 )
 
 
-def show(parent=None, targets=[], modal=None):
+def show(parent=None, targets=None, modal=None):
     from . import host
+
+    if targets is None:
+        targets = []
     return host.show(parent, targets, modal)
 
 

--- a/pyblish_qml/__init__.py
+++ b/pyblish_qml/__init__.py
@@ -5,9 +5,9 @@ from .version import (
 )
 
 
-def show(parent=None, targets=[]):
+def show(parent=None, targets=[], modal=None):
     from . import host
-    return host.show(parent, targets)
+    return host.show(parent, targets, modal)
 
 
 _state = {}

--- a/pyblish_qml/host.py
+++ b/pyblish_qml/host.py
@@ -132,6 +132,7 @@ def show(parent=None, targets=[], modal=None):
 
     return server
 
+
 def publish():
     # get existing GUI
     if _state.get("currentServer"):
@@ -145,6 +146,7 @@ def publish():
             # The running instance has already been closed.
             _state.pop("currentServer")
 
+
 def validate():
     # get existing GUI
     if _state.get("currentServer"):
@@ -157,6 +159,7 @@ def validate():
         except IOError:
             # The running instance has already been closed.
             _state.pop("currentServer")
+
 
 def install_callbacks():
     pyblish.api.register_callback("instanceToggled", _toggle_instance)
@@ -256,8 +259,12 @@ def _connect_host_event(app):
 
     class HostEventFilter(QtWidgets.QWidget):
 
-        eventList = [QtCore.QEvent.Show, QtCore.QEvent.Hide,
-                QtCore.QEvent.WindowActivate, QtCore.QEvent.WindowDeactivate]
+        eventList = [
+            QtCore.QEvent.Show,
+            QtCore.QEvent.Hide,
+            QtCore.QEvent.WindowActivate,
+            QtCore.QEvent.WindowDeactivate
+        ]
 
         def getServer(self):
             server = None

--- a/pyblish_qml/host.py
+++ b/pyblish_qml/host.py
@@ -41,7 +41,7 @@ def current_server():
     return _state.get("currentServer")
 
 
-def install():
+def install(modal):
     """Perform first time install
 
     Attributes:
@@ -55,7 +55,7 @@ def install():
         uninstall()
 
     install_callbacks()
-    install_host()
+    install_host(modal)
 
     _state["installed"] = True
 
@@ -66,7 +66,7 @@ def uninstall():
     sys.stdout.write("Pyblish QML shutdown successful.\n")
 
 
-def show(parent=None, targets=[]):
+def show(parent=None, targets=[], modal=None):
     """Attempt to show GUI
 
     Requires install() to have been run first, and
@@ -74,9 +74,13 @@ def show(parent=None, targets=[]):
 
     """
 
+    # Get modal mode from environment
+    if modal is None:
+        modal = bool(os.environ.get("PYBLISH_QML_MODAL", False))
+
     # Automatically install if not already installed.
     if not _state.get("installed"):
-        install()
+        install(modal)
 
     # Show existing GUI
     if _state.get("currentServer"):
@@ -109,7 +113,7 @@ def show(parent=None, targets=[]):
 
     try:
         service = ipc.service.Service()
-        server = ipc.server.Server(service, targets=targets)
+        server = ipc.server.Server(service, targets=targets, modal=modal)
     except Exception:
         # If for some reason, the GUI fails to show.
         traceback.print_exc()
@@ -123,6 +127,8 @@ def show(parent=None, targets=[]):
 
     print("Success. QML server available as "
           "pyblish_qml.api.current_server()")
+
+    server.listen()
 
     return server
 
@@ -202,7 +208,7 @@ def register_pyqt5(path):
     _state["pyqt5"] = path
 
 
-def install_host():
+def install_host(modal):
     """Install required components into supported hosts
 
     An unsupported host will still run, but may encounter issues,
@@ -216,7 +222,7 @@ def install_host():
                     _install_hiero,
                     _install_nukestudio):
         try:
-            install()
+            install(modal)
         except ImportError:
             pass
         else:
@@ -240,7 +246,7 @@ def _on_application_quit():
 
 def _connect_host_event(app):
     """Connect some event from host to QML
-    
+
     Host will connect following event to QML:
     QEvent.Show                -> rise QML
     QEvent.Hide                -> hide QML
@@ -250,7 +256,7 @@ def _connect_host_event(app):
 
     class HostEventFilter(QtWidgets.QWidget):
 
-        eventList = [QtCore.QEvent.Show, QtCore.QEvent.Hide, 
+        eventList = [QtCore.QEvent.Show, QtCore.QEvent.Hide,
                 QtCore.QEvent.WindowActivate, QtCore.QEvent.WindowDeactivate]
 
         def getServer(self):
@@ -316,7 +322,7 @@ def _connect_host_event(app):
         pass
 
 
-def _install_maya():
+def _install_maya(modal):
     """Helper function to Autodesk Maya support"""
     from maya import utils
 
@@ -325,7 +331,8 @@ def _install_maya():
             func, *args, **kwargs)
 
     sys.stdout.write("Setting up Pyblish QML in Maya\n")
-    register_dispatch_wrapper(threaded_wrapper)
+    if not modal:
+        register_dispatch_wrapper(threaded_wrapper)
 
     app = QtWidgets.QApplication.instance()
     app.aboutToQuit.connect(_on_application_quit)
@@ -337,7 +344,7 @@ def _install_maya():
         settings.WindowTitle = "Pyblish (Maya)"
 
 
-def _install_houdini():
+def _install_houdini(modal):
     """Helper function to SideFx Houdini support"""
     import hdefereval
 
@@ -346,7 +353,8 @@ def _install_houdini():
             func, *args, **kwargs)
 
     sys.stdout.write("Setting up Pyblish QML in Houdini\n")
-    register_dispatch_wrapper(threaded_wrapper)
+    if not modal:
+        register_dispatch_wrapper(threaded_wrapper)
 
     app = QtWidgets.QApplication.instance()
     app.aboutToQuit.connect(_on_application_quit)
@@ -358,7 +366,7 @@ def _install_houdini():
         settings.WindowTitle = "Pyblish (Houdini)"
 
 
-def _install_nuke():
+def _install_nuke(modal):
     """Helper function to The Foundry Nuke support"""
     import nuke
 
@@ -370,7 +378,8 @@ def _install_nuke():
             func, args, kwargs)
 
     sys.stdout.write("Setting up Pyblish QML in Nuke\n")
-    register_dispatch_wrapper(threaded_wrapper)
+    if not modal:
+        register_dispatch_wrapper(threaded_wrapper)
 
     app = QtWidgets.QApplication.instance()
     app.aboutToQuit.connect(_on_application_quit)
@@ -382,7 +391,7 @@ def _install_nuke():
         settings.WindowTitle = "Pyblish (Nuke)"
 
 
-def _install_hiero():
+def _install_hiero(modal):
     """Helper function to The Foundry Hiero support"""
     import hiero
     import nuke
@@ -395,7 +404,8 @@ def _install_hiero():
             func, args, kwargs)
 
     sys.stdout.write("Setting up Pyblish QML in Hiero\n")
-    register_dispatch_wrapper(threaded_wrapper)
+    if not modal:
+        register_dispatch_wrapper(threaded_wrapper)
 
     app = QtWidgets.QApplication.instance()
     app.aboutToQuit.connect(_on_application_quit)
@@ -407,7 +417,7 @@ def _install_hiero():
         settings.WindowTitle = "Pyblish (Hiero)"
 
 
-def _install_nukestudio():
+def _install_nukestudio(modal):
     """Helper function to The Foundry Hiero support"""
     import nuke
 
@@ -419,7 +429,8 @@ def _install_nukestudio():
             func, args, kwargs)
 
     sys.stdout.write("Setting up Pyblish QML in NukeStudio\n")
-    register_dispatch_wrapper(threaded_wrapper)
+    if not modal:
+        register_dispatch_wrapper(threaded_wrapper)
 
     app = QtWidgets.QApplication.instance()
     app.aboutToQuit.connect(_on_application_quit)

--- a/pyblish_qml/ipc/server.py
+++ b/pyblish_qml/ipc/server.py
@@ -91,10 +91,18 @@ class Server(object):
 
     """
 
-    def __init__(self, service, python=None, pyqt5=None, targets=[]):
+    def __init__(self,
+                 service,
+                 python=None,
+                 pyqt5=None,
+                 targets=[],
+                 modal=False):
         super(Server, self).__init__()
         self.service = service
         self.listening = False
+
+        # Store modal state
+        self.modal = modal
 
         # The server may be run within Maya or some other host,
         # in which case we refer to it as running embedded.
@@ -179,7 +187,6 @@ class Server(object):
         kwargs["args"].extend(targets)
 
         self.popen = subprocess.Popen(**kwargs)
-        self.listen()
 
     def stop(self):
         try:
@@ -251,9 +258,12 @@ class Server(object):
                         sys.stdout.write(line)
 
         if not self.listening:
-            thread = threading.Thread(target=_listen)
-            thread.daemon = True
-            thread.start()
+            if self.modal:
+                _listen()
+            else:
+                thread = threading.Thread(target=_listen)
+                thread.daemon = True
+                thread.start()
 
             self.listening = True
 

--- a/pyblish_qml/version.py
+++ b/pyblish_qml/version.py
@@ -1,7 +1,7 @@
 
 VERSION_MAJOR = 1
-VERSION_MINOR = 4
-VERSION_PATCH = 5
+VERSION_MINOR = 5
+VERSION_PATCH = 0
 
 version_info = (VERSION_MAJOR, VERSION_MINOR, VERSION_PATCH)
 version = '%i.%i.%i' % version_info


### PR DESCRIPTION
This PR implements a modal mode and a way to switch between modal and non-modal.

The motivation for a modal mode is because of threading issues in Nuke reported in #264.

**Usage**

Non-modal is the default when using ```pyblish_qml.show()```.

To invoke modal mode you can either explicitly call ```pyblish_qml.show(modal=True)``` or set the environment variable ```os.environ["PYBLISH_QML_MODAL"] = "True"```.