### PR TITLE
Check icon

### DIFF
--- a/pyblish_qml/qml/Pyblish/CheckBox.qml
+++ b/pyblish_qml/qml/Pyblish/CheckBox.qml
@@ -10,6 +10,7 @@ MouseArea {
 
     property bool active: true
     property bool checked: false
+    property alias icon: check.name
 
     property var statuses: {
         "default": "white",

--- a/pyblish_qml/qml/Pyblish/ListItems/SectionItem.qml
+++ b/pyblish_qml/qml/Pyblish/ListItems/SectionItem.qml
@@ -15,7 +15,7 @@ Item {
     property string text
 
     property var statuses: {
-        "default": "#222",
+        "default": "#ddd",
         "processing": Theme.primaryColor,
         "success": Theme.dark.successColor,
         "warning": Theme.dark.warningColor,

--- a/pyblish_qml/qml/Pyblish/ListItems/StandardActions.qml
+++ b/pyblish_qml/qml/Pyblish/ListItems/StandardActions.qml
@@ -74,6 +74,18 @@ MouseArea {
         CheckBox {
             id: indicator
 
+            icon: {
+                if (status == "processing")
+                    return ""
+                if (status == "error")
+                    return "exclamation"
+                if (status == "warning")
+                    return "check"
+                if (status == "success")
+                    return "check"
+                return "check"
+            }
+
             active: listItem.active
             checked: listItem.checked
 


### PR DESCRIPTION
Along the theme of section colors, I wanted to see what it'd look like to update the checkbox icon with something other than the check, as check normally means "all good", which isn't the case when things error.

![untitled project](https://user-images.githubusercontent.com/2152766/33979696-72bed5a0-e09d-11e7-9dce-f10c16137899.gif)

Not sure it's an improvement.. Welcome to tinker.

As I was writing this, I discovered a minor bug in the previously merged PR; namely that the section icon went too dark when unexpanded and had no status.

![untitled project](https://user-images.githubusercontent.com/2152766/33979650-3faf0ce8-e09d-11e7-8a8d-98e38c8e8f61.gif)
