### PR TITLE
Fix #283

### DIFF
--- a/pyblish_qml/qml/Pyblish/CheckBox.qml
+++ b/pyblish_qml/qml/Pyblish/CheckBox.qml
@@ -59,12 +59,14 @@ MouseArea {
         anchors.centerIn: parent
 
         color: {
-          if (status == "success")
-            return Qt.darker(check.color, 1.5)
-          if (status == "warning")
-            return Qt.darker(check.color, 1.5)
-          if (status == "error")
-            return Qt.darker(check.color, 1.5)
+          if (checked) {
+              if (status == "success")
+                return Qt.darker(check.color, 1.5)
+              if (status == "warning")
+                return Qt.darker(check.color, 1.5)
+              if (status == "error")
+                return Qt.darker(check.color, 1.5)
+          }
           return "transparent"
         }
         border.color: check.color


### PR DESCRIPTION
This fixes #283 

Though, on toggling an instance off for a very brief moment the "checked" icon is visible. Not sure if that's a problem, but it's because that one fades over a brief time: 
```
NumberAnimation {
                duration: 100
            }
```

Current result: https://i.gyazo.com/9ecf5c88571b859c2953772c4c00bd33.mp4