### PR TITLE
Changed actionsIconVisible loop breaking for section indicator updating

### DIFF
--- a/pyblish_qml/models.py
+++ b/pyblish_qml/models.py
@@ -499,9 +499,7 @@ class ItemModel(AbstractModel):
             item.duration += result["duration"]
             item.finishedAt = time.time()
 
-            if item.itemType == "plugin":
-                if item.actionsIconVisible:
-                    continue
+            if item.itemType == "plugin" and not item.actionsIconVisible:
 
                 actions = list(item.actions)
 


### PR DESCRIPTION
After adding hide-able section function, updating `actionsIconVisible` state
may skip section update if the action menu exists.

So instead of `continue if True` which skipping the rest of the code,
changed to `if not True`.

This will solve #285 .