### PR TITLE
Add support for mandatory instances

### DIFF
--- a/pyblish_qml/ipc/formatting.py
+++ b/pyblish_qml/ipc/formatting.py
@@ -133,6 +133,9 @@ def format_data(data):
         "publish",
         "comment",
 
+        # Allows an instance to be non-optional (ie, mandatory)
+        "optional",
+
         # Provided by service.py
         "host",
         "port",

--- a/pyblish_qml/version.py
+++ b/pyblish_qml/version.py
@@ -1,7 +1,7 @@
 
 VERSION_MAJOR = 1
 VERSION_MINOR = 7
-VERSION_PATCH = 3
+VERSION_PATCH = 4
 
 version_info = (VERSION_MAJOR, VERSION_MINOR, VERSION_PATCH)
 version = '%i.%i.%i' % version_info


### PR DESCRIPTION
`pyblish-lite` implements this by omitting the checkbox when an Instance has `.data['optional'] = False`, effectively making an instance "mandatory" (in whatever state it was added.)

With this PR, `pyblish-qml` implements mandatory isntances by greying out the checkbox, just like it's already doing for the "Context" entry in the top left. Clicking on them shows a "Cannot toggle." status prompt.

To show what this looks like, here's a dummy Collector I used:
```python
class Collector(pyblish.api.ContextPlugin):
    order = pyblish.api.CollectorOrder
    def process(self, context):
        instance = context.create_instance('farmer', family='human')
        instance.data['optional'] = False
        instance.data['publish'] = True
        for i in range(3):
            instance = context.create_instance('potato%s' % i, family='vegetable')
            instance.data['optional'] = True
            instance.data['publish'] = False
```

And here's what this looks like in action:

![pyblishqml_mandatory_instances](https://user-images.githubusercontent.com/941331/42573829-2216fa36-84eb-11e8-93be-908bca784903.gif)

and for comparison, the same Collector without the PR's changes, in action:

![pyblishqml_mandatory_instances_not_working](https://user-images.githubusercontent.com/941331/42573847-3441c07e-84eb-11e8-9d30-9aa2ec08c72b.gif)

and the same Collector again, with the latest official release of `pyblish-lite`:

![pyblishlite_mandatory_instances](https://user-images.githubusercontent.com/941331/42574514-7fc913b6-84ec-11e8-92db-e1dc452b4d8b.gif)


If this was to be merged, it would fix issue #291.