### PR TITLE
Implemented eventFilter removal and improved Foster stability

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,11 @@ api.register_gui("pyblish_qml")
 
 See [pyblish-maya](https://github.com/pyblish/pyblish-maya#usage) for an example.
 
+**Additional Environment Variables**
+
+- `PYBLISH_QML_FOSTER=1` Make QML process a real child of parent process, this makes the otherwise external process act like a native window within a host, to appear below inner windows such as the Script Editor in Maya.
+- `PYBLISH_QML_MODAL=1` Block interactions to parent process, useful for headless publishing where you expect a process to remain alive for as long as QML is. Without this, Pyblish is at the mercy of the parent process, e.g. `mayapy` which quits at the first sign of EOF.
+
 <br>
 <br>
 <br>

--- a/pyblish_qml/app.py
+++ b/pyblish_qml/app.py
@@ -268,16 +268,6 @@ class Application(QtGui.QGuiApplication):
             window.setFlags(previous_flags | QtCore.Qt.WindowStaysOnTopHint)
             window.setFlags(previous_flags)
 
-    def _set_goemetry(self, source, target):
-        """Set window position and size after parent swap"""
-        target.setFramePosition(source.framePosition())
-
-        window_state = source.windowState()
-        target.setWindowState(window_state)
-
-        if not window_state == QtCore.Qt.WindowMaximized:
-            target.resize(source.size())
-
     def detach(self):
         """Detach QQuickView window from the host
 
@@ -297,14 +287,15 @@ class Application(QtGui.QGuiApplication):
         print("Detach window from foster parent...")
 
         self.vessel = self.native_vessel
-
-        self.host.detach()
-
         self.fostered = False
-        self.vessel.show()
 
-        self.window.setParent(self.vessel)
-        self._set_goemetry(self.foster_vessel, self.vessel)
+        self.window.setParent(self.native_vessel)
+        # Show dst container
+        self.native_vessel.show()
+        self.native_vessel.setGeometry(self.foster_vessel.geometry())
+        # Hide src container
+        self.host.detach()
+        # Stay on top
         self._popup()
 
         self.controller.detached.emit()
@@ -328,14 +319,16 @@ class Application(QtGui.QGuiApplication):
         print("Attach window to foster parent...")
 
         self.vessel = self.foster_vessel
-
-        self.host.attach()
-
-        self.native_vessel.hide()
         self.fostered = True
 
-        self.window.setParent(self.vessel)
-        self._set_goemetry(self.native_vessel, self.vessel)
+        self.window.setParent(self.foster_vessel)
+        # Show dst container
+        self.host.attach()
+        self.foster_vessel.setGeometry(self.native_vessel.geometry())
+        # Hide src container
+        self.native_vessel.hide()
+        # Stay on top
+        self.host.popup()
 
         self.controller.attached.emit()
 

--- a/pyblish_qml/app.py
+++ b/pyblish_qml/app.py
@@ -234,6 +234,9 @@ class Application(QtGui.QGuiApplication):
 
         print("\n".join(message))
 
+        if self.fostered and self.ninja:
+            self.native_vessel.show()
+
         self.window.requestActivate()
         self.window.showNormal()
 
@@ -257,16 +260,6 @@ class Application(QtGui.QGuiApplication):
 
         # Allow time for QML to initialise
         util.schedule(self.controller.reset, 500, channel="main")
-
-        if self.fostered and self.ninja:
-            # Reclaim window after first rest
-            self.window.setParent(self.foster_vessel)
-            self.foster_vessel.show()
-            # Hide src container
-            self.native_vessel.setOpacity(0)  # avoid hide window anim
-            self.native_vessel.hide()
-            # Ensure at front
-            self.window.requestActivate()
 
     def hide(self):
         """Hide GUI

--- a/pyblish_qml/app.py
+++ b/pyblish_qml/app.py
@@ -23,9 +23,9 @@ ICON_PATH = os.path.join(MODULE_DIR, "icon.ico")
 class Window(QtQuick.QQuickView):
     """Main application window"""
 
-    def __init__(self, app):
+    def __init__(self):
         super(Window, self).__init__(None)
-        self.app = app
+        self.app = QtGui.QGuiApplication.instance()
 
         self.setTitle(settings.WindowTitle)
         self.setResizeMode(self.SizeRootObjectToView)
@@ -59,9 +59,9 @@ class Window(QtQuick.QQuickView):
 class NativeVessel(QtGui.QWindow):
     """Container window"""
 
-    def __init__(self, app):
+    def __init__(self):
         super(NativeVessel, self).__init__(None)
-        self.app = app
+        self.app = QtGui.QGuiApplication.instance()
 
     def resizeEvent(self, event):
         self.app.resize(self.width(), self.height())
@@ -109,9 +109,9 @@ class Application(QtGui.QGuiApplication):
 
         self.setWindowIcon(QtGui.QIcon(ICON_PATH))
 
-        native_vessel = NativeVessel(self)
+        native_vessel = NativeVessel()
 
-        window = Window(self)
+        window = Window()
         window.statusChanged.connect(self.on_status_changed)
 
         engine = window.engine()

--- a/pyblish_qml/app.py
+++ b/pyblish_qml/app.py
@@ -125,7 +125,7 @@ class Application(QtGui.QGuiApplication):
         context.setContextProperty("app", controller)
 
         self.fostered = False
-        self.ninja = False
+        self.foster_fixed = False
 
         self.foster_vessel = None
         self.native_vessel = native_vessel
@@ -180,7 +180,7 @@ class Application(QtGui.QGuiApplication):
             super(Application, self).quit()
 
     @util.SlotSentinel()
-    def show(self, client_settings=None, window_id=None, ninja=False):
+    def show(self, client_settings=None, window_id=None, foster_fixed=False):
         """Display GUI
 
         Once the QML interface has been loaded, use this
@@ -206,7 +206,7 @@ class Application(QtGui.QGuiApplication):
 
             self.window.setParent(foster_vessel)
             self.foster_vessel = foster_vessel
-            self.ninja = ninja
+            self.foster_fixed = foster_fixed
 
         if client_settings:
             # Apply client-side settings
@@ -222,7 +222,7 @@ class Application(QtGui.QGuiApplication):
             first_appearance_setup(self.native_vessel)
 
             if self.fostered:
-                if self.ninja:
+                if not self.foster_fixed:
                     # Return it back to native vessel for first run
                     self.window.setParent(self.native_vessel)
                 first_appearance_setup(self.foster_vessel)
@@ -234,7 +234,7 @@ class Application(QtGui.QGuiApplication):
 
         print("\n".join(message))
 
-        if self.fostered and self.ninja:
+        if self.fostered and not self.foster_fixed:
             self.native_vessel.show()
 
         self.window.requestActivate()
@@ -316,7 +316,7 @@ class Application(QtGui.QGuiApplication):
         This is the part that detaching from host.
 
         """
-        if not self.ninja:
+        if self.foster_fixed or self.foster_vessel is None:
             self.controller.detached.emit()
             return
 
@@ -351,11 +351,10 @@ class Application(QtGui.QGuiApplication):
         This is the part that attaching back to host.
 
         """
-        if not self.ninja:
-            if self.foster_vessel is not None:
-                # Send alert
-                self.host.popup(alert)
+        if self.foster_fixed or self.foster_vessel is None:
             self.controller.attached.emit()
+            if self.foster_vessel is not None:
+                self.host.popup(alert)  # Send alert
             return
 
         print("Attach window to foster parent...")

--- a/pyblish_qml/app.py
+++ b/pyblish_qml/app.py
@@ -98,7 +98,7 @@ class Application(QtGui.QGuiApplication):
     inFocused = QtCore.pyqtSignal()
     outFocused = QtCore.pyqtSignal()
 
-    attached = QtCore.pyqtSignal()
+    attached = QtCore.pyqtSignal(QtCore.QVariant)
     detached = QtCore.pyqtSignal()
     host_attached = QtCore.pyqtSignal()
     host_detached = QtCore.pyqtSignal()
@@ -257,6 +257,8 @@ class Application(QtGui.QGuiApplication):
             # Hide src container
             self.native_vessel.setOpacity(0)  # avoid hide window anim
             self.native_vessel.hide()
+            # Ensure at front
+            self.window.requestActivate()
 
     def hide(self):
         """Hide GUI
@@ -336,7 +338,7 @@ class Application(QtGui.QGuiApplication):
 
         self.controller.detached.emit()
 
-    def attach(self):
+    def attach(self, alert=False):
         """Attach QQuickView window to the host
 
         In foster mode, inorder to prevent window freeze when the host's
@@ -365,7 +367,7 @@ class Application(QtGui.QGuiApplication):
         self.native_vessel.setOpacity(0)  # avoid hide window anim
         self.native_vessel.hide()
         # Stay on top
-        self.host.popup()
+        self.host.popup(alert)
 
         self.controller.attached.emit()
 

--- a/pyblish_qml/app.py
+++ b/pyblish_qml/app.py
@@ -232,11 +232,11 @@ class Application(QtGui.QGuiApplication):
         via a call to `show()`
 
         """
-        self.vessel.hide()
+        self.window.hide()
 
     def rise(self):
         """Rise GUI from hidden"""
-        self.vessel.show()
+        self.window.show()
 
     def inFocus(self):
         """Set GUI on-top flag"""

--- a/pyblish_qml/app.py
+++ b/pyblish_qml/app.py
@@ -68,8 +68,12 @@ class NativeVessel(QtGui.QWindow):
 
     def event(self, event):
         # Is required for Foster mode
+        # Native vessel will receive closeEvent while foster mode is on
+        # and is the parent of window.
         if event.type() == QtCore.QEvent.Close:
             self.app.window.event(event)
+            if event.isAccepted():
+                self.app.quit()
 
         return super(NativeVessel, self).event(event)
 
@@ -163,6 +167,9 @@ class Application(QtGui.QGuiApplication):
 
     def quit(self):
         if self.fostered:
+            # Foster vessel's closeEvent will trigger "quit" which connected
+            # to here.
+            # Forward the event to window.
             self.window.event(QtCore.QEvent(QtCore.QEvent.Close))
         super(Application, self).quit()
 

--- a/pyblish_qml/app.py
+++ b/pyblish_qml/app.py
@@ -162,7 +162,8 @@ class Application(QtGui.QGuiApplication):
         self.clients.pop(port)
 
     def quit(self):
-        self.controller.host.emit("pyblishQmlClose")
+        if self.fostered:
+            self.window.event(QtCore.QEvent(QtCore.QEvent.Close))
         super(Application, self).quit()
 
     @util.SlotSentinel()

--- a/pyblish_qml/app.py
+++ b/pyblish_qml/app.py
@@ -296,6 +296,7 @@ class Application(QtGui.QGuiApplication):
         # Hide src container
         self.host.detach()
         # Stay on top
+        self.window.requestActivate()
         self._popup()
 
         self.controller.detached.emit()

--- a/pyblish_qml/app.py
+++ b/pyblish_qml/app.py
@@ -325,9 +325,9 @@ class Application(QtGui.QGuiApplication):
         self.window.setParent(self.native_vessel)
 
         # Show dst container
-        self.native_vessel.setOpacity(100)
         self.native_vessel.show()
         self.native_vessel.setGeometry(self.foster_vessel.geometry())
+        self.native_vessel.setOpacity(100)
         # Hide src container (will wait for host)
         host_detached = QtTest.QSignalSpy(self.host_detached)
         self.host.detach()

--- a/pyblish_qml/app.py
+++ b/pyblish_qml/app.py
@@ -283,14 +283,14 @@ class Application(QtGui.QGuiApplication):
 
     def inFocus(self):
         """Set GUI on-top flag"""
-        if not self.fostered and os.name == "nt":
+        if not self.fostered:
             previous_flags = self.window.flags()
             self.window.setFlags(previous_flags |
                                  QtCore.Qt.WindowStaysOnTopHint)
 
     def outFocus(self):
         """Remove GUI on-top flag"""
-        if not self.fostered and os.name == "nt":
+        if not self.fostered:
             previous_flags = self.window.flags()
             self.window.setFlags(previous_flags ^
                                  QtCore.Qt.WindowStaysOnTopHint)
@@ -303,7 +303,7 @@ class Application(QtGui.QGuiApplication):
         self.window.resize(width, height)
 
     def _popup(self):
-        if not self.fostered and os.name == "nt":
+        if not self.fostered:
             window = self.window
             # Work-around for window appearing behind
             # other windows upon being shown once hidden.

--- a/pyblish_qml/control.py
+++ b/pyblish_qml/control.py
@@ -770,8 +770,7 @@ class Controller(QtCore.QObject):
 
             self.host.emit("reset", context=None)
 
-            if not self.data["firstRun"]:
-                self.attach()
+            self.attach()
 
             # Hidden sections
             for section in self.data["models"]["item"].sections:

--- a/pyblish_qml/control.py
+++ b/pyblish_qml/control.py
@@ -139,8 +139,8 @@ class Controller(QtCore.QObject):
         detached = QtTest.QSignalSpy(self.detached)
         detached.wait(1000)
 
-    def attach(self):
-        signal = json.dumps({"payload": {"name": "attach"}})
+    def attach(self, alert=False):
+        signal = json.dumps({"payload": {"name": "attach", "args": [alert]}})
         self.host.channels["parent"].put(signal)
         attached = QtTest.QSignalSpy(self.attached)
         attached.wait(1000)
@@ -869,7 +869,7 @@ class Controller(QtCore.QObject):
             self.run(*args, callback=on_finished)
 
         def on_finished():
-            self.attach()
+            self.attach(True)
             self.host.emit("published", context=None)
 
         self.detach()
@@ -913,7 +913,7 @@ class Controller(QtCore.QObject):
             self.run(*args, callback=on_finished)
 
         def on_finished():
-            self.attach()
+            self.attach(True)
             self.host.emit("validated", context=None)
 
         self.detach()

--- a/pyblish_qml/control.py
+++ b/pyblish_qml/control.py
@@ -770,6 +770,8 @@ class Controller(QtCore.QObject):
 
             self.host.emit("reset", context=None)
 
+            self.attach()
+
             # Hidden sections
             for section in self.data["models"]["item"].sections:
                 if section.name in settings.HiddenSections:
@@ -822,6 +824,7 @@ class Controller(QtCore.QObject):
         def on_reset():
             util.async(self.host.context, callback=on_context)
 
+        self.detach()
         util.async(self.host.reset, callback=on_reset)
 
     @QtCore.pyqtSlot()

--- a/pyblish_qml/control.py
+++ b/pyblish_qml/control.py
@@ -770,7 +770,8 @@ class Controller(QtCore.QObject):
 
             self.host.emit("reset", context=None)
 
-            self.attach()
+            if not self.data["firstRun"]:
+                self.attach()
 
             # Hidden sections
             for section in self.data["models"]["item"].sections:
@@ -824,7 +825,8 @@ class Controller(QtCore.QObject):
         def on_reset():
             util.async(self.host.context, callback=on_context)
 
-        self.detach()
+        if not self.data["firstRun"]:
+            self.detach()
         util.async(self.host.reset, callback=on_reset)
 
     @QtCore.pyqtSlot()

--- a/pyblish_qml/host.py
+++ b/pyblish_qml/host.py
@@ -106,6 +106,24 @@ def _fosterable(foster, modal):
         return False
 
 
+def _foster_ninja(foster):
+    if not foster:
+        return False
+
+    value = os.environ.get("PYBLISH_QML_FOSTER_NINJA", "").lower()
+    if value in ("true", "yes", "1"):
+        return True
+
+    elif value in ("false", "no", "0"):
+        return False
+
+    else:
+        if QtCore.qVersion()[0] == "5":
+            return True
+        else:
+            return False
+
+
 def show(parent=None, targets=[], modal=None, foster=None):
     """Attempt to show GUI
 
@@ -121,6 +139,7 @@ def show(parent=None, targets=[], modal=None, foster=None):
     is_headless = _is_headless()
 
     foster = _fosterable(foster, modal)
+    ninja = _foster_ninja(foster)
 
     # Automatically install if not already installed.
     if not _state.get("installed"):
@@ -164,7 +183,8 @@ def show(parent=None, targets=[], modal=None, foster=None):
         server = ipc.server.Server(service,
                                    targets=targets,
                                    modal=modal,
-                                   foster=foster)
+                                   foster=foster,
+                                   ninja=ninja)
     except Exception:
         # If for some reason, the GUI fails to show.
         traceback.print_exc()
@@ -388,11 +408,7 @@ class HostEventFilter(QtWidgets.QWidget):
 
         if connected is not True:
             # The running instance has already been closed.
-            self.parent().removeEventFilter(self)
-            if _state.get("eventFilter") is self:
-                _state.pop("eventFilter")
-
-            print("The eventFilter of pyblish-qml has self removed.\n")
+            remove_event_filter()
 
         return True
 

--- a/pyblish_qml/host.py
+++ b/pyblish_qml/host.py
@@ -175,10 +175,10 @@ def show(parent=None, targets=[], modal=None, foster=None):
     print("Success. QML server available as "
           "pyblish_qml.api.current_server()")
 
-    server.listen()
-
     # Install eventFilter if not exists one
     install_event_filter()
+
+    server.listen()
 
     return server
 

--- a/pyblish_qml/host.py
+++ b/pyblish_qml/host.py
@@ -281,11 +281,13 @@ def install_event_filter():
         raise Exception("Main window not found, event filter did not "
                         "install. This is a bug.")
 
+    event_filter = _state.get("eventFilter", HostEventFilter(main_window))
     try:
-        host_event_filter = HostEventFilter(main_window)
-        main_window.installEventFilter(host_event_filter)
+        main_window.installEventFilter(event_filter)
     except Exception:
         pass
+    else:
+        _state["eventFilter"] = event_filter
 
 
 def _on_application_quit():

--- a/pyblish_qml/host.py
+++ b/pyblish_qml/host.py
@@ -64,7 +64,7 @@ def install(modal, foster):
         sys.stdout.write("Already installed, uninstalling..\n")
         uninstall()
 
-    use_threaded_wrapper = foster or not modal
+    use_threaded_wrapper = not modal
 
     install_callbacks()
     install_host(use_threaded_wrapper)
@@ -89,17 +89,21 @@ def _is_headless():
     )
 
 
-def _fosterable(foster=None):
+def _fosterable(foster, modal):
     if foster is None:
         # Get foster mode from environment
         foster = bool(os.environ.get("PYBLISH_QML_FOSTER", False))
 
     if foster:
-        os.environ["PYBLISH_QML_FOSTER"] = "True"
-    else:
-        os.environ["PYBLISH_QML_FOSTER"] = ""
+        if modal or _is_headless():
+            print("Foster disabled due to Modal is on or in headless mode.")
+            return False
 
-    return foster and not _is_headless()
+        print("Foster on.")
+        return True
+
+    else:
+        return False
 
 
 def show(parent=None, targets=[], modal=None, foster=None):
@@ -116,7 +120,7 @@ def show(parent=None, targets=[], modal=None, foster=None):
 
     is_headless = _is_headless()
 
-    foster = _fosterable(foster)
+    foster = _fosterable(foster, modal)
 
     # Automatically install if not already installed.
     if not _state.get("installed"):

--- a/pyblish_qml/host.py
+++ b/pyblish_qml/host.py
@@ -380,7 +380,6 @@ class HostEventFilter(QtWidgets.QWidget):
             # proxy is None, or does not have the function
             return False
 
-        print(func_name)
         connected = func()
 
         if connected is not True:

--- a/pyblish_qml/host.py
+++ b/pyblish_qml/host.py
@@ -106,12 +106,12 @@ def _fosterable(foster, modal):
         return False
 
 
-def _foster_ninja(foster):
+def _foster_fixed(foster):
     if not foster:
         return False
 
-    value = os.environ.get("PYBLISH_QML_FOSTER_NINJA", "").lower()
-    return value in ("true", "yes", "1") or QtCore.qVersion()[0] == "5"
+    value = os.environ.get("PYBLISH_QML_FOSTER_FIXED", "").lower()
+    return value in ("true", "yes", "1") or QtCore.qVersion()[0] == "4"
 
 
 def show(parent=None, targets=[], modal=None, foster=None):
@@ -135,7 +135,7 @@ def show(parent=None, targets=[], modal=None, foster=None):
     is_headless = _is_headless()
 
     foster = _fosterable(foster, modal)
-    ninja = _foster_ninja(foster)
+    foster_fixed = _foster_fixed(foster)
 
     # Automatically install if not already installed.
     if not _state.get("installed"):
@@ -180,7 +180,7 @@ def show(parent=None, targets=[], modal=None, foster=None):
                                    targets=targets,
                                    modal=modal,
                                    foster=foster,
-                                   ninja=ninja)
+                                   foster_fixed=foster_fixed)
     except Exception:
         # If for some reason, the GUI fails to show.
         traceback.print_exc()

--- a/pyblish_qml/host.py
+++ b/pyblish_qml/host.py
@@ -111,17 +111,7 @@ def _foster_ninja(foster):
         return False
 
     value = os.environ.get("PYBLISH_QML_FOSTER_NINJA", "").lower()
-    if value in ("true", "yes", "1"):
-        return True
-
-    elif value in ("false", "no", "0"):
-        return False
-
-    else:
-        if QtCore.qVersion()[0] == "5":
-            return True
-        else:
-            return False
+    return value in ("true", "yes", "1") or QtCore.qVersion()[0] == "5"
 
 
 def show(parent=None, targets=[], modal=None, foster=None):
@@ -129,6 +119,12 @@ def show(parent=None, targets=[], modal=None, foster=None):
 
     Requires install() to have been run first, and
     a live instance of Pyblish QML in the background.
+
+    Arguments:
+        parent (None, optional): Deprecated
+        targets (list, optional): Publishing targets
+        modal (bool, optional): Block interactions to parent
+        foster (bool, optional): Become a real child of the parent process
 
     """
 

--- a/pyblish_qml/host.py
+++ b/pyblish_qml/host.py
@@ -305,7 +305,7 @@ def remove_event_filter():
             except (KeyError, ValueError):
                 pass
 
-        print("The eventFilter of pyblish-qml has been removed.\n")
+        print("The eventFilter of pyblish-qml has been removed.")
 
 
 def install_event_filter():

--- a/pyblish_qml/ipc/client.py
+++ b/pyblish_qml/ipc/client.py
@@ -36,8 +36,9 @@ class Proxy(object):
     def detach(self):
         self._dispatch("detach")
 
-    def attach(self):
-        self._dispatch("attach")
+    def attach(self, qRect):
+        geometry = [qRect.x(), qRect.y(), qRect.width(), qRect.height()]
+        self._dispatch("attach", args=geometry)
 
     def popup(self):
         self._dispatch("popup")

--- a/pyblish_qml/ipc/client.py
+++ b/pyblish_qml/ipc/client.py
@@ -39,6 +39,9 @@ class Proxy(object):
     def attach(self):
         self._dispatch("attach")
 
+    def popup(self):
+        self._dispatch("popup")
+
     def test(self, **vars):
         """Vars can only be passed as a non-keyword argument"""
         return self._dispatch("test", kwargs=vars)

--- a/pyblish_qml/ipc/client.py
+++ b/pyblish_qml/ipc/client.py
@@ -40,8 +40,8 @@ class Proxy(object):
         geometry = [qRect.x(), qRect.y(), qRect.width(), qRect.height()]
         self._dispatch("attach", args=geometry)
 
-    def popup(self):
-        self._dispatch("popup")
+    def popup(self, alert):
+        self._dispatch("popup", args=[alert])
 
     def test(self, **vars):
         """Vars can only be passed as a non-keyword argument"""

--- a/pyblish_qml/ipc/server.py
+++ b/pyblish_qml/ipc/server.py
@@ -85,7 +85,7 @@ class Proxy(object):
     def hide(self):
         """Hide the GUI"""
         self._dispatch("hide")
-        self.vessel.hide()
+        return self.vessel.hide()
 
     def quit(self):
         """Ask the GUI to quit"""
@@ -94,15 +94,15 @@ class Proxy(object):
     def rise(self):
         """Rise GUI from hidden"""
         self.vessel.show()
-        self._dispatch("rise")
+        return self._dispatch("rise")
 
     def inFocus(self):
         """Set GUI on-top flag"""
-        self._dispatch("inFocus")
+        return self._dispatch("inFocus")
 
     def outFocus(self):
         """Remove GUI on-top flag"""
-        self._dispatch("outFocus")
+        return self._dispatch("outFocus")
 
     def kill(self):
         """Forcefully destroy the process"""
@@ -127,20 +127,6 @@ class Proxy(object):
 
     def validate(self):
         return self._dispatch("validate")
-
-    def _remove_event_filter(self):
-        event_filter = _state.get("eventFilter")
-        if isinstance(event_filter, QtCore.QObject):
-
-            # (NOTE) Should remove from the QApp instance which originally
-            #        installed to.
-            #        This will not work:
-            #        `QApplication.instance().removeEventFilter(event_filter)`
-            #
-            event_filter.parent().removeEventFilter(event_filter)
-            del _state["eventFilter"]
-
-            print("The eventFilter of pyblish-qml has been removed.\n")
 
     def _alive(self):
         """Send pulse to child process
@@ -192,7 +178,6 @@ class Proxy(object):
         except IOError:
             # subprocess closed
             self.vessel.close()
-            self._remove_event_filter()
         else:
             return True
 

--- a/pyblish_qml/ipc/server.py
+++ b/pyblish_qml/ipc/server.py
@@ -115,8 +115,12 @@ class Proxy(object):
         self.vessel.setGeometry(x, y, w, h)
         self._dispatch("host_attach")
 
-    def popup(self):
-        self.vessel.activateWindow()  # to top
+    def popup(self, alert):
+        # No hijack keyboard focus
+        QtWidgets.QApplication.setActiveWindow(self.vessel)
+        # Plus alert
+        if alert:
+            QtWidgets.QApplication.alert(self.vessel.parent(), 0)
 
     def publish(self):
         return self._dispatch("publish")

--- a/pyblish_qml/ipc/server.py
+++ b/pyblish_qml/ipc/server.py
@@ -104,11 +104,12 @@ class Proxy(object):
             settings (optional, dict): Client settings
 
         """
-        if not self.ninja:
+        if self.ninja:
+            return self._dispatch("show", args=[settings or {},
+                                                self._winId,
+                                                self.ninja])
+        else:
             self.vessel.show()
-        return self._dispatch("show", args=[settings or {},
-                                            self._winId,
-                                            self.ninja])
 
     def hide(self):
         """Hide the GUI"""
@@ -224,6 +225,10 @@ class Server(object):
         service (service.Service): Dispatch requests to this service
         python (str, optional): Absolute path to Python executable
         pyqt5 (str, optional): Absolute path to PyQt5
+        targets (list, optional): Publishing targets, e.g. `ftrack`
+        modal (bool, optional): Block interactions to parent
+        foster (bool, optional): Become a real child of the parent process
+        ninja (bool, optional): ...?
 
     """
 

--- a/pyblish_qml/ipc/server.py
+++ b/pyblish_qml/ipc/server.py
@@ -343,6 +343,10 @@ class Server(object):
                             getattr(self.proxy, func_name)(*args)
                             result = None
 
+                        elif func_name in ("emit",):
+                            # Avoid main thread hang
+                            result = getattr(self.service, func_name)(*args)
+
                         else:
                             wrapper = _state.get("dispatchWrapper",
                                                  default_wrapper)

--- a/pyblish_qml/ipc/server.py
+++ b/pyblish_qml/ipc/server.py
@@ -93,6 +93,7 @@ class Proxy(object):
 
     def rise(self):
         """Rise GUI from hidden"""
+        self.vessel.show()
         self._dispatch("rise")
 
     def inFocus(self):

--- a/pyblish_qml/ipc/server.py
+++ b/pyblish_qml/ipc/server.py
@@ -38,8 +38,6 @@ class FosterVessel(QtWidgets.QDialog):
         self._winId = winIdFixed(self.winId())
 
         self.resize(1, 1)
-        # Modal Mode
-        self.setModal(proxy.modal)
 
         self.proxy = proxy
 
@@ -62,7 +60,6 @@ class Proxy(object):
     def __init__(self, server):
 
         self.popen = server.popen
-        self.modal = server.modal
         self.foster = server.foster
 
         self.vessel = FosterVessel(self) if self.foster else MockFosterVessel()
@@ -383,7 +380,7 @@ class Server(object):
                         sys.stdout.write(line)
 
         if not self.listening:
-            if self.modal and not self.foster:
+            if self.modal:
                 _listen()
             else:
                 thread = threading.Thread(target=_listen)

--- a/pyblish_qml/ipc/server.py
+++ b/pyblish_qml/ipc/server.py
@@ -76,7 +76,6 @@ class Proxy(object):
             settings (optional, dict): Client settings
 
         """
-        self.vessel.show()
         return self._dispatch("show", args=[settings or {}, self._winId])
 
     def hide(self):

--- a/pyblish_qml/ipc/server.py
+++ b/pyblish_qml/ipc/server.py
@@ -119,6 +119,20 @@ class Proxy(object):
     def validate(self):
         return self._dispatch("validate")
 
+    def _remove_event_filter(self):
+        event_filter = _state.get("eventFilter")
+        if isinstance(event_filter, QtCore.QObject):
+
+            # (NOTE) Should remove from the QApp instance which originally
+            #        installed to.
+            #        This will not work:
+            #        `QApplication.instance().removeEventFilter(event_filter)`
+            #
+            event_filter.parent().removeEventFilter(event_filter)
+            del _state["eventFilter"]
+
+            print("The eventFilter of pyblish-qml has been removed.")
+
     def _alive(self):
         """Send pulse to child process
 
@@ -169,6 +183,7 @@ class Proxy(object):
         except IOError:
             # subprocess closed
             self.vessel.close()
+            self._remove_event_filter()
         else:
             return True
 

--- a/pyblish_qml/ipc/server.py
+++ b/pyblish_qml/ipc/server.py
@@ -73,7 +73,7 @@ class Proxy(object):
 
         self.popen = server.popen
         self.foster = server.foster
-        self.ninja = server.ninja
+        self.foster_fixed = server.foster_fixed
 
         self.vessel = FosterVessel(self) if self.foster else MockFosterVessel()
         self._winId = self.vessel._winId
@@ -104,11 +104,11 @@ class Proxy(object):
             settings (optional, dict): Client settings
 
         """
-        if not self.ninja:
+        if self.foster_fixed:
             self.vessel.show()
         return self._dispatch("show", args=[settings or {},
                                             self._winId,
-                                            self.ninja])
+                                            self.foster_fixed])
 
     def hide(self):
         """Hide the GUI"""
@@ -149,7 +149,7 @@ class Proxy(object):
 
     def popup(self, alert):
         # No hijack keyboard focus
-        if self.ninja:
+        if not self.foster_fixed:
             QtWidgets.QApplication.setActiveWindow(self.vessel)
         # Plus alert
         if alert:
@@ -226,8 +226,8 @@ class Server(object):
         pyqt5 (str, optional): Absolute path to PyQt5
         targets (list, optional): Publishing targets, e.g. `ftrack`
         modal (bool, optional): Block interactions to parent
-        foster (bool, optional): Become a real child of the parent process
-        ninja (bool, optional): ...?
+        foster (bool, optional): GUI become a real child of the parent process
+        foster_fixed (bool, optional): GUI always remain inside the parent
 
     """
 
@@ -238,7 +238,7 @@ class Server(object):
                  targets=[],
                  modal=False,
                  foster=False,
-                 ninja=False):
+                 foster_fixed=False):
         super(Server, self).__init__()
         self.service = service
         self.listening = False
@@ -249,7 +249,7 @@ class Server(object):
         self.modal = modal
 
         self.foster = foster
-        self.ninja = ninja
+        self.foster_fixed = foster_fixed
 
         # The server may be run within Maya or some other host,
         # in which case we refer to it as running embedded.

--- a/pyblish_qml/ipc/server.py
+++ b/pyblish_qml/ipc/server.py
@@ -104,12 +104,11 @@ class Proxy(object):
             settings (optional, dict): Client settings
 
         """
-        if self.ninja:
-            return self._dispatch("show", args=[settings or {},
-                                                self._winId,
-                                                self.ninja])
-        else:
+        if not self.ninja:
             self.vessel.show()
+        return self._dispatch("show", args=[settings or {},
+                                            self._winId,
+                                            self.ninja])
 
     def hide(self):
         """Hide the GUI"""

--- a/pyblish_qml/ipc/server.py
+++ b/pyblish_qml/ipc/server.py
@@ -109,10 +109,15 @@ class Proxy(object):
         self.popen.kill()
 
     def detach(self):
+        self.vessel.setWindowOpacity(0)  # avoid hide window anim
         self.vessel.hide()
+        self._dispatch("host_detach")
 
-    def attach(self):
+    def attach(self, x, y, w, h):
+        self.vessel.setWindowOpacity(100)
         self.vessel.show()
+        self.vessel.setGeometry(x, y, w, h)
+        self._dispatch("host_attach")
 
     def popup(self):
         self.vessel.activateWindow()  # to top
@@ -135,7 +140,7 @@ class Proxy(object):
             event_filter.parent().removeEventFilter(event_filter)
             del _state["eventFilter"]
 
-            print("The eventFilter of pyblish-qml has been removed.")
+            print("The eventFilter of pyblish-qml has been removed.\n")
 
     def _alive(self):
         """Send pulse to child process
@@ -353,7 +358,7 @@ class Server(object):
                         # self.service have no access to proxy object, so
                         # this `if` statement is needed
                         if func_name in ("detach", "attach", "popup"):
-                            getattr(self.proxy, func_name)()
+                            getattr(self.proxy, func_name)(*args)
                             result = None
 
                         else:

--- a/pyblish_qml/ipc/server.py
+++ b/pyblish_qml/ipc/server.py
@@ -114,6 +114,9 @@ class Proxy(object):
     def attach(self):
         self.vessel.show()
 
+    def popup(self):
+        self.vessel.activateWindow()  # to top
+
     def publish(self):
         return self._dispatch("publish")
 
@@ -349,7 +352,7 @@ class Server(object):
 
                         # self.service have no access to proxy object, so
                         # this `if` statement is needed
-                        if func_name in ("detach", "attach"):
+                        if func_name in ("detach", "attach", "popup"):
                             getattr(self.proxy, func_name)()
                             result = None
 

--- a/pyblish_qml/ipc/server.py
+++ b/pyblish_qml/ipc/server.py
@@ -110,9 +110,9 @@ class Proxy(object):
         self._dispatch("host_detach")
 
     def attach(self, x, y, w, h):
-        self.vessel.setWindowOpacity(100)
         self.vessel.show()
         self.vessel.setGeometry(x, y, w, h)
+        self.vessel.setWindowOpacity(100)
         self._dispatch("host_attach")
 
     def popup(self, alert):

--- a/pyblish_qml/version.py
+++ b/pyblish_qml/version.py
@@ -1,7 +1,7 @@
 
 VERSION_MAJOR = 1
 VERSION_MINOR = 8
-VERSION_PATCH = 1
+VERSION_PATCH = 2
 
 version_info = (VERSION_MAJOR, VERSION_MINOR, VERSION_PATCH)
 version = '%i.%i.%i' % version_info


### PR DESCRIPTION
In this PR, should have:
* eventFilter auto remove after quitting under any conditions
    - No matter `foster` is on or not, usual window close or force quit, should remove evenFilter in the end.
* Foster mode should work under any versions of Maya
    - Behavior may differ by the Qt version on host, in my observation, host which running Qt4 could not render QML window properly while window setParent back to subprocess (*window detach-attach*), which meant for avoiding main thread busy. So in this PR, in order to guaranty the visual feedback, those Qt4 host will not be able to avoid main thread busy (lag better then blank).
    - For test propose, you can turn *detach-attach* on or off by setting environment variable `PYBLISH_QML_FOSTER_NINJA=True` or `False` (`Yes/No 1/0`)
* In any condition, window should able to ignore closeEvent while processing, unless force quitting
   - This was broken in my previous PR. :(
* Host main window should blink alert on validation/publish complete when in foster mode
   - In foster mode, the alert can only be shown on host main window.
* Fake child approach's OS limitation removed
   - Was only enabled on Windows, limitation is gone now.

Here are some Foster mode running screen gif:

This is Maya 2018.0 on Windows

![qml_foster_windows](https://user-images.githubusercontent.com/3357009/44949548-a00e7780-ae66-11e8-9e33-4ba1e29400d0.gif)

This is Maya 2015 on Windows

![qml_foster_2015](https://user-images.githubusercontent.com/3357009/44949550-a3a1fe80-ae66-11e8-8404-c518f6f72959.gif)

As you can see, it's really laggy.

This is Maya 2017 update 5 on CentOS 7 (Run in Hyper-V)

![qml_foster_linux](https://user-images.githubusercontent.com/3357009/44949551-a7ce1c00-ae66-11e8-8676-191bf797970d.gif)

Foster mode works on CentOS !
One thing to be noticed is that, while in my first test on CentOS, I installed Maya 2017 and encountered an error says:
`FosterVessel(QtWidgets.QDialog) has no attribute 'winId'`
This is a bug, the error was gone after I installed the Maya 2017 update.

Now, I wouldn't say the Foster mode is 100% safe to use, but should at least stable as Fake child approach.

Any feedback are welcome :)
Thanks !

