### PR TITLE
Add setup.cfg to tell bdist_wheel that we want a 'universal' wheel.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,9 +23,9 @@ script:
 deploy:
   provider: pypi
   user: mottosso
+  distributions: "sdist bdist_wheel"
   password:
     secure: NKekJIgRr/kaDXsK6Vz4rj3Uuxk6gK1NsrlAkAqXX8bPSS2oLpp8KVN2SjoCizwdO+sZzry6q0WdbeqnqRwiTTdnotlyVqjbmFNfTCeRdqZKAqYDvfSe44eNWCQgf06zl0lErX9NrJuPnJWyXqutvojdm50b99NzkiO60I+Fr6M=
   on:
     tags: true
-    distributions: sdist bdist_wheel
     repo: pyblish/pyblish-qml

--- a/pyblish_qml/version.py
+++ b/pyblish_qml/version.py
@@ -1,7 +1,7 @@
 
 VERSION_MAJOR = 1
 VERSION_MINOR = 8
-VERSION_PATCH = 2
+VERSION_PATCH = 3
 
 version_info = (VERSION_MAJOR, VERSION_MINOR, VERSION_PATCH)
 version = '%i.%i.%i' % version_info

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,7 @@
+[metadata]
+# This includes the license file in the wheel.
+license_file = LICENSE
+
+[bdist_wheel]
+# This produces a "universal" (Py2+3) wheel.
+universal = 1


### PR DESCRIPTION
`.travis.yml` is already configured to make a wheel file, but not a universal one.

This fixes that.
