### PR TITLE
Minor fix: eventFilter drop on minimized; comments lost sync after GUI rest

### DIFF
--- a/pyblish_qml/app.py
+++ b/pyblish_qml/app.py
@@ -328,7 +328,7 @@ class Application(QtGui.QGuiApplication):
         # Show dst container
         self.native_vessel.show()
         self.native_vessel.setGeometry(self.foster_vessel.geometry())
-        self.native_vessel.setOpacity(100)
+        self.native_vessel.setOpacity(1)
         # Hide src container (will wait for host)
         host_detached = QtTest.QSignalSpy(self.host_detached)
         self.host.detach()

--- a/pyblish_qml/control.py
+++ b/pyblish_qml/control.py
@@ -617,6 +617,11 @@ class Controller(QtCore.QObject):
         """Append `data` to result model"""
         self.data["models"]["result"].add_item(data)
 
+    def comment_sync(self, comment):
+        """Update comments to host and notify subscribers"""
+        self.host.update(key="comment", value=comment)
+        self.host.emit("commented", comment=comment)
+
     # Event handlers
 
     def on_commenting(self, comment):
@@ -628,8 +633,7 @@ class Controller(QtCore.QObject):
             self.data["comment"] = comment
 
             # Notify subscribers of the comment
-            self.host.update(key="comment", value=comment)
-            self.host.emit("commented", comment=comment)
+            self.comment_sync(comment)
 
             self.commented.emit()
 
@@ -765,8 +769,7 @@ class Controller(QtCore.QObject):
                 self.data["comment"] = comment
 
             # Notify subscribers of the comment
-            self.host.update(key="comment", value=comment)
-            self.host.emit("commented", comment=comment)
+            self.comment_sync(comment)
 
             if self.data["firstRun"]:
                 self.firstRun.emit()

--- a/pyblish_qml/control.py
+++ b/pyblish_qml/control.py
@@ -764,6 +764,10 @@ class Controller(QtCore.QObject):
                 comment = self.host.cached_context.data.get("comment", "")
                 self.data["comment"] = comment
 
+            # Notify subscribers of the comment
+            self.host.update(key="comment", value=comment)
+            self.host.emit("commented", comment=comment)
+
             if self.data["firstRun"]:
                 self.firstRun.emit()
                 self.data["firstRun"] = False

--- a/pyblish_qml/ipc/server.py
+++ b/pyblish_qml/ipc/server.py
@@ -145,7 +145,7 @@ class Proxy(object):
     def attach(self, x, y, w, h):
         self.vessel.show()
         self.vessel.setGeometry(x, y, w, h)
-        self.vessel.setWindowOpacity(100)
+        self.vessel.setWindowOpacity(1)
         self._dispatch("host_attach")
 
     def popup(self, alert):

--- a/pyblish_qml/ipc/server.py
+++ b/pyblish_qml/ipc/server.py
@@ -112,8 +112,9 @@ class Proxy(object):
 
     def hide(self):
         """Hide the GUI"""
-        self._dispatch("hide")
-        return self.vessel.hide()
+        success = self._dispatch("hide")
+        self.vessel.hide()
+        return success
 
     def quit(self):
         """Ask the GUI to quit"""

--- a/pyblish_qml/version.py
+++ b/pyblish_qml/version.py
@@ -1,7 +1,7 @@
 
 VERSION_MAJOR = 1
 VERSION_MINOR = 8
-VERSION_PATCH = 2
+VERSION_PATCH = 4
 
 version_info = (VERSION_MAJOR, VERSION_MINOR, VERSION_PATCH)
 version = '%i.%i.%i' % version_info


### PR DESCRIPTION
This PR will provide two fix:
1. eventFilter get removed when main window minimized.
    > did not found this bug on previous PR, sorry :(
2. Comment did not restore back to host after rest, here's the scenario:
    1. Artists input comments to QML comment box
    2. Validation failed or some other cases that make artist to **press `reset` botton**
    3. Comments remain in QML comment box and **did not make any new input**
    4. Published, but the comment did not collect to database