### PR TITLE
Fix to remove all empty categories in action menu

### DIFF
--- a/pyblish_qml/control.py
+++ b/pyblish_qml/control.py
@@ -379,7 +379,8 @@ class Controller(QtCore.QObject):
             if action["on"] == "notProcessed" and item.processed:
                 actions.remove(action)
 
-        # Discard empty groups
+        # Discard empty categories, separators
+        remaining_actions = list()
         index = 0
         try:
             action = actions[index]
@@ -394,7 +395,7 @@ class Controller(QtCore.QObject):
 
                 isempty = False
 
-                if action["__type__"] == "category":
+                if action["__type__"] in ("category", "separator"):
                     try:
                         next_ = actions[index + 1]
                         if next_["__type__"] != "action":
@@ -402,12 +403,12 @@ class Controller(QtCore.QObject):
                     except IndexError:
                         isempty = True
 
-                    if isempty:
-                        actions.pop(index)
+                if not isempty:
+                    remaining_actions.append(action)
 
                 index += 1
 
-        return actions
+        return remaining_actions
 
     @QtCore.pyqtSlot(str)
     def runPluginAction(self, action):

--- a/pyblish_qml/version.py
+++ b/pyblish_qml/version.py
@@ -1,7 +1,7 @@
 
 VERSION_MAJOR = 1
 VERSION_MINOR = 8
-VERSION_PATCH = 4
+VERSION_PATCH = 5
 
 version_info = (VERSION_MAJOR, VERSION_MINOR, VERSION_PATCH)
 version = '%i.%i.%i' % version_info


### PR DESCRIPTION
### Problem

Plugins which using multiple `Category` or `Separator` to organize `Action` may produce an action menu that left some `Category` or `Separator` uncleaned in GUI.

![qml_menu_before](https://user-images.githubusercontent.com/3357009/46039984-b7791180-c141-11e8-9abc-fc1abbddc3cf.gif)

As you can see, in those two action menus, there are an empty `Category` *C* and a `Separator` with no actions to separate.

### Fix

![qml_menu_after](https://user-images.githubusercontent.com/3357009/46040324-8816d480-c142-11e8-94f2-076dc937335c.gif)

I like to use `Category`, and with this PR, redundant `Category` and `Separator` would be taken care of.

🍺 🍺 

<details>
<summary>Reproducible Code</summary>

```python

import pyblish.api


class CollectInstances(pyblish.api.ContextPlugin):

    order = pyblish.api.CollectorOrder

    def process(self, context):
        context.create_instance(name="Dummy")


class ActionToAll(pyblish.api.Action):
    on = "all"
    label = "Action to All"


class ActionOnFailed(pyblish.api.Action):
    on = "failed"
    label = "Action On Failed"


class ValidateFailed(pyblish.api.InstancePlugin):

    order = pyblish.api.ValidatorOrder
    label = "Many Categories"

    actions = [
        pyblish.api.Category("A"),
        ActionToAll,
        pyblish.api.Category("B"),
        ActionOnFailed,
        pyblish.api.Category("C"),
        ActionOnFailed,
    ]

    def process(self, instance):
        assert True is False


class ValidatePass(pyblish.api.InstancePlugin):

    order = pyblish.api.ValidatorOrder
    label = "With Separator"

    actions = [
        pyblish.api.Category("A"),
        ActionToAll,
        pyblish.api.Separator,
        ActionOnFailed,
    ]

    def process(self, instance):
        assert True


pyblish.api.register_plugin(CollectInstances)
pyblish.api.register_plugin(ValidateFailed)
pyblish.api.register_plugin(ValidatePass)

```

</details>