### PR TITLE
Enhancement, fix #281, #274 and #119

### DIFF
--- a/pyblish_qml/control.py
+++ b/pyblish_qml/control.py
@@ -517,19 +517,19 @@ class Controller(QtCore.QObject):
         model = self.data["models"]["item"]
 
         states = set([item.isToggled for item in model.items
-                      if (item.itemType == 'instance' and
+                      if (item.itemType == "instance" and
                           sectionLabel == item.family)])
 
         if len(states) == 1:
             checkState = not states.pop()
 
         for item in model.items:
-            if item.itemType == 'instance' and sectionLabel == item.family:
+            if item.itemType == "instance" and sectionLabel == item.family:
                 if item.isToggled != checkState:
                     self.__toggle_item(model,
                                        model.items.index(item))
 
-            if item.itemType == 'plugin' and item.optional:
+            if item.itemType == "plugin" and item.optional:
                 if item.verb == sectionLabel:
                     if item.isToggled != checkState:
                         self.__toggle_item(

--- a/pyblish_qml/control.py
+++ b/pyblish_qml/control.py
@@ -481,6 +481,13 @@ class Controller(QtCore.QObject):
     def toggleSection(self, checkState, sectionLabel):
         model = self.data["models"]["item"]
 
+        states = set([item.isToggled for item in model.items
+                      if (item.itemType == 'instance' and
+                          sectionLabel == item.family)])
+
+        if len(states) == 1:
+            checkState = not states.pop()
+
         for item in model.items:
             if item.itemType == 'instance' and sectionLabel == item.family:
                 if item.isToggled != checkState:

--- a/pyblish_qml/ipc/client.py
+++ b/pyblish_qml/ipc/client.py
@@ -225,10 +225,8 @@ class ContextProxy(pyblish.api.Context):
         self = cls()
         self._id = context["id"]
         self._data = context["data"]
-
-        instances = list(InstanceProxy.from_json(i)
-                         for i in context["children"])
-        self[:] = sorted(instances, key=lambda i: i._data["family"])
+        self[:] = list(InstanceProxy.from_json(i)
+                       for i in context["children"])
 
         # Attach metadata
         self._data["pyblishClientVersion"] = pyblish.api.version

--- a/pyblish_qml/ipc/client.py
+++ b/pyblish_qml/ipc/client.py
@@ -225,8 +225,10 @@ class ContextProxy(pyblish.api.Context):
         self = cls()
         self._id = context["id"]
         self._data = context["data"]
-        self[:] = list(InstanceProxy.from_json(i)
-                       for i in context["children"])
+
+        instances = list(InstanceProxy.from_json(i)
+                         for i in context["children"])
+        self[:] = sorted(instances, key=lambda i: i._data["family"])
 
         # Attach metadata
         self._data["pyblishClientVersion"] = pyblish.api.version

--- a/pyblish_qml/qml/Footer.qml
+++ b/pyblish_qml/qml/Footer.qml
@@ -10,6 +10,7 @@ View {
     // 0 = Default; 1 = Publishing; 2 = Finished
     property int mode: 0
     property bool paused: false
+    property bool startup: true
 
     signal publish
     signal validate

--- a/pyblish_qml/qml/Overview.qml
+++ b/pyblish_qml/qml/Overview.qml
@@ -16,6 +16,8 @@ Item {
 
     property string __lastPlugin
 
+    property bool validated: false
+
     signal instanceEntered(int index)
     signal pluginEntered(int index)
 
@@ -206,7 +208,13 @@ Item {
 
         visible: overview.state != "initialising"
 
-        mode: overview.state == "publishing" ? 1 : overview.state == "finished" ? 2 : 0
+        mode: {
+            if (startup == true) {
+                setMessage("Collecting..")
+                return 1
+            }
+            return overview.state == "publishing" ? 1 : overview.state == "finished" ? 2 : 0
+        }
 
         width: parent.width
         anchors.bottom: parent.bottom
@@ -228,6 +236,7 @@ Item {
         onFirstRun: {
             app.commentEnabled ? commentBox.up() : null
             commentBox.text = app.comment()
+            footer.startup = false
         }
 
         onStateChanged: {
@@ -241,14 +250,31 @@ Item {
                 setMessage("Initialising..")
             }
 
-            if (state == "publishing") {
+            if (state == "collecting") {
                 overview.state = "publishing"
-                setMessage("Publishing..")
+                setMessage("Collecting..")
+            }
+
+            if (state == "validating") {
+                overview.state = "publishing"
+                setMessage("Validating..")
+                overview.validated = false
+            }
+
+            if (state == "extracting") {
+                overview.state = "publishing"
+                setMessage("Extracting..")
+                overview.validated = true
+            }
+
+            if (state == "integrating") {
+                overview.state = "publishing"
+                setMessage("Integrating..")
             }
 
             if (state == "finished") {
                 overview.state = "finished"
-                setMessage("Finished..")
+                overview.validated ? setMessage("Published") : setMessage("Validated")
             }
 
             if (state == "stopping") {


### PR DESCRIPTION
This PR provide 2 fix and 1 extra feature:
* Fix #281: No need to press twice when section items were all manually toggled on/off.
* Fix #274 and #119: Status message are now more specific.
* Able to press stop on collecting, which I think would be a bit improve on UX.

### Before

![qml_enhance_before](https://user-images.githubusercontent.com/3357009/46307695-34950280-c5ea-11e8-8265-0113cde6ec12.gif)

### After

![qml_enhance_after](https://user-images.githubusercontent.com/3357009/46307701-38288980-c5ea-11e8-890e-f076251d51a0.gif)

