### PR TITLE
Fix #304, increase QML initialization waiting time

### DIFF
--- a/pyblish_qml/app.py
+++ b/pyblish_qml/app.py
@@ -259,7 +259,7 @@ class Application(QtGui.QGuiApplication):
         self.controller.show.emit()
 
         # Allow time for QML to initialise
-        util.schedule(self.controller.reset, 500, channel="main")
+        util.schedule(self.controller.reset, 1500, channel="main")
 
     def hide(self):
         """Hide GUI

--- a/pyblish_qml/control.py
+++ b/pyblish_qml/control.py
@@ -641,13 +641,13 @@ class Controller(QtCore.QObject):
         new_value = not item.isToggled
         old_value = item.isToggled
 
-        if item.itemType == 'plugin':
+        if item.itemType == "plugin":
             self.host.emit("pluginToggled",
                            plugin=item.id,
                            new_value=new_value,
                            old_value=old_value)
 
-        if item.itemType == 'instance':
+        if item.itemType == "instance":
             self.host.emit("instanceToggled",
                            instance=item.id,
                            new_value=new_value,

--- a/pyblish_qml/qml/Footer.qml
+++ b/pyblish_qml/qml/Footer.qml
@@ -10,7 +10,6 @@ View {
     // 0 = Default; 1 = Publishing; 2 = Finished
     property int mode: 0
     property bool paused: false
-    property bool startup: true
 
     signal publish
     signal validate

--- a/pyblish_qml/qml/Overview.qml
+++ b/pyblish_qml/qml/Overview.qml
@@ -208,15 +208,7 @@ Item {
 
         visible: overview.state != "initialising"
 
-        mode: {
-            if (startup === true) {
-                // Ensure collecting process is stoppable on first run
-                setMessage("Collecting..")
-                return 1
-            }
-
-            return overview.state == "publishing" ? 1 : overview.state == "finished" ? 2 : 0
-        }
+        mode:  overview.state == "publishing" ? 1 : overview.state == "finished" ? 2 : 0
 
         width: parent.width
         anchors.bottom: parent.bottom
@@ -238,7 +230,6 @@ Item {
         onFirstRun: {
             app.commentEnabled ? commentBox.up() : null
             commentBox.text = app.comment()
-            footer.startup = false
         }
 
         onStateChanged: {

--- a/pyblish_qml/qml/Overview.qml
+++ b/pyblish_qml/qml/Overview.qml
@@ -209,14 +209,10 @@ Item {
         visible: overview.state != "initialising"
 
         mode: {
-            if (app.state === "collecting" && startup === true) {
+            if (startup === true) {
                 // Ensure collecting process is stoppable on first run
                 setMessage("Collecting..")
                 return 1
-            }
-            if (overview.state == "") {
-                // Make sure the message get displayed on first run
-                setMessage("Ready")
             }
 
             return overview.state == "publishing" ? 1 : overview.state == "finished" ? 2 : 0

--- a/pyblish_qml/qml/Overview.qml
+++ b/pyblish_qml/qml/Overview.qml
@@ -209,10 +209,16 @@ Item {
         visible: overview.state != "initialising"
 
         mode: {
-            if (startup == true) {
+            if (app.state === "collecting" && startup === true) {
+                // Ensure collecting process is stoppable on first run
                 setMessage("Collecting..")
                 return 1
             }
+            if (overview.state == "") {
+                // Make sure the message get displayed on first run
+                setMessage("Ready")
+            }
+
             return overview.state == "publishing" ? 1 : overview.state == "finished" ? 2 : 0
         }
 


### PR DESCRIPTION
### Problem
In previous PR #304, the new feature that allow user to stop collecting process at startup, will make GUI stuck at "Collecting.." phase if the collecting process ended in *short time* (before QML get initialized).

That feature rely on QML to receive the signal `firstRun` to reset those button, so if the signal `firstRun` emitted before QML complete initialization, GUI stocked.

### Fix
Increase QML initialization waiting time from `500` to `1500`, give it enough time to be ready to receive signal `firstRun`