### PR TITLE
Fix state machine transision bug from PR #304

### DIFF
--- a/pyblish_qml/control.py
+++ b/pyblish_qml/control.py
@@ -253,6 +253,7 @@ class Controller(QtCore.QObject):
         validating.addTransition(self.extracting, extracting)
 
         extracting.addTransition(self.stopping, stopping)
+        extracting.addTransition(self.finished, finished)
         extracting.addTransition(self.integrating, integrating)
 
         integrating.addTransition(self.stopping, stopping)

--- a/pyblish_qml/version.py
+++ b/pyblish_qml/version.py
@@ -1,7 +1,7 @@
 
 VERSION_MAJOR = 1
 VERSION_MINOR = 8
-VERSION_PATCH = 6
+VERSION_PATCH = 7
 
 version_info = (VERSION_MAJOR, VERSION_MINOR, VERSION_PATCH)
 version = '%i.%i.%i' % version_info


### PR DESCRIPTION
In the state machine, `extracting` state needs to transition to `finished` if the validation failed during the publish, or the stop button won't change to reset button, and cause user operation not able to continue.

![qml_fix304_before](https://user-images.githubusercontent.com/3357009/46586648-1a5c9800-cab4-11e8-8f07-1c1a1b490ebf.gif)

This commit fixed that.

![qml_fix304_after](https://user-images.githubusercontent.com/3357009/46586649-1cbef200-cab4-11e8-9c29-92acf927fc00.gif)

---

Somehow I missed this one in the previous tests, after founding this bug in my work, right after the release of `1.8.6`, I spend a day did a series of user operation flow inspection, including each kind of `Action`, and compared the outcome with previous releases, so far this is the only one that I have missed based on previous PRs.
