### PR TITLE
Fix #308

### DIFF
--- a/pyblish_qml/ipc/server.py
+++ b/pyblish_qml/ipc/server.py
@@ -386,8 +386,8 @@ class Server(object):
                             getattr(self.proxy, func_name)(*args)
                             result = None
 
-                        elif func_name in ("emit",):
-                            # Avoid main thread hang
+                        elif self.foster and func_name in ("emit",):
+                            # Avoid main thread hang on Foster Mode
                             result = getattr(self.service, func_name)(*args)
 
                         else:


### PR DESCRIPTION
After the investigation, the reason that cause #308 was the threading issue inside the Linux version of Maya 2016, the commit d2c503b fixed that.

That line of code in commit d2c503b, was introduced from the implementation of *Foster Mode*, thus, in order to make sure there are no other issue on host side that has never happened before, I refactored the `Server` and the `Proxy` in commit 4449e5c, which will ensure them worked just like the version before `1.8.0`. The major difference was the `proxy` object gets reused from `server` object, and it better not be.

@darkvertex, this is ready for you to test, the issue should be gone now :)

And since I was testing these changes mostly on Linux, in next couple days I will go back to Windows to run some more tests on other versions of Maya and perhaps on other hosts, too.
