### PR TITLE
Fix 309

### DIFF
--- a/pyblish_qml/control.py
+++ b/pyblish_qml/control.py
@@ -507,6 +507,7 @@ class Controller(QtCore.QObject):
             if item.itemType == "instance" and sectionLabel == item.category:
                 if item.optional:
                     states.add(item.isToggled)
+
             if item.itemType == "plugin" and sectionLabel == item.verb:
                 if item.optional:
                     states.add(item.isToggled)
@@ -517,13 +518,11 @@ class Controller(QtCore.QObject):
         for item in model.items:
             if item.itemType == "instance" and sectionLabel == item.category:
                 if item.isToggled != checkState and item.optional:
-                    self.__toggle_item(model,
-                                       model.items.index(item))
+                    self.__toggle_item(model, model.items.index(item))
 
             if item.itemType == "plugin" and sectionLabel == item.verb:
                 if item.isToggled != checkState and item.optional:
-                    self.__toggle_item(model,
-                                       model.items.index(item))
+                    self.__toggle_item(model, model.items.index(item))
 
     @QtCore.pyqtSlot(bool, str)
     def hideSection(self, hideState, sectionLabel):

--- a/pyblish_qml/control.py
+++ b/pyblish_qml/control.py
@@ -502,25 +502,28 @@ class Controller(QtCore.QObject):
     def toggleSection(self, checkState, sectionLabel):
         model = self.data["models"]["item"]
 
-        states = set([item.isToggled for item in model.items
-                      if (item.itemType == "instance" and
-                          sectionLabel == item.category)])
+        states = set()
+        for item in model.items:
+            if item.itemType == "instance" and sectionLabel == item.category:
+                if item.optional:
+                    states.add(item.isToggled)
+            if item.itemType == "plugin" and sectionLabel == item.verb:
+                if item.optional:
+                    states.add(item.isToggled)
 
         if len(states) == 1:
             checkState = not states.pop()
 
         for item in model.items:
             if item.itemType == "instance" and sectionLabel == item.category:
-                if item.isToggled != checkState:
+                if item.isToggled != checkState and item.optional:
                     self.__toggle_item(model,
                                        model.items.index(item))
 
-            if item.itemType == "plugin" and item.optional:
-                if item.verb == sectionLabel:
-                    if item.isToggled != checkState:
-                        self.__toggle_item(
-                            model,
-                            model.items.index(item))
+            if item.itemType == "plugin" and sectionLabel == item.verb:
+                if item.isToggled != checkState and item.optional:
+                    self.__toggle_item(model,
+                                       model.items.index(item))
 
     @QtCore.pyqtSlot(bool, str)
     def hideSection(self, hideState, sectionLabel):

--- a/pyblish_qml/control.py
+++ b/pyblish_qml/control.py
@@ -502,6 +502,7 @@ class Controller(QtCore.QObject):
     def toggleSection(self, checkState, sectionLabel):
         model = self.data["models"]["item"]
 
+        # Get all items' current toggle state
         states = set()
         for item in model.items:
             if item.itemType == "instance" and sectionLabel == item.category:
@@ -513,6 +514,8 @@ class Controller(QtCore.QObject):
                     states.add(item.isToggled)
 
         if len(states) == 1:
+            # Use items' states instead of section state if all optional items
+            # are the same state.
             checkState = not states.pop()
 
         for item in model.items:

--- a/pyblish_qml/version.py
+++ b/pyblish_qml/version.py
@@ -1,7 +1,7 @@
 
 VERSION_MAJOR = 1
 VERSION_MINOR = 9
-VERSION_PATCH = 0
+VERSION_PATCH = 1
 
 version_info = (VERSION_MAJOR, VERSION_MINOR, VERSION_PATCH)
 version = '%i.%i.%i' % version_info


### PR DESCRIPTION
This PR will fix #309 , and UX bug related to #281 but on plugin section.

### Before
![qml_309](https://user-images.githubusercontent.com/3357009/51082257-703d7d80-173e-11e9-92d3-54bbbcfe2bdd.gif)

* The instance `Batman` and `David` should not be toggled, but the restriction got bypassed via toggling the section.
* Plugin checkbox did not give immediate respond to section toggling.

### After
![qml_309fix](https://user-images.githubusercontent.com/3357009/51082258-72074100-173e-11e9-81b4-b22a083b038b.gif)

* All fixed !

### Implementation

1. Collect all *optional* items' state.
2. Override section state if all optional items are in the same state. This guaranteed the optional item be able to respond to every toggle.
3. Set check state.

