### PR TITLE
Implementing #315

### DIFF
--- a/pyblish_qml/control.py
+++ b/pyblish_qml/control.py
@@ -991,6 +991,8 @@ class Controller(QtCore.QObject):
 
             self.data["models"]["item"].update_with_result(result)
             self.data["models"]["result"].update_with_result(result)
+            # Update proxy instance data which currently being iterated in
+            # the primary iterator
             update_instance_with_result(result)
 
             # Once the main thread has finished updating
@@ -1006,8 +1008,7 @@ class Controller(QtCore.QObject):
             proxy = next((i for i in context if i.id == id), None)
             if proxy is None:
                 return
-            # Update proxy instance data which currently being iterated in
-            # the primary iterator
+
             proxy.data["publish"] = data.get("publish", True)
             proxy.data["family"] = data["family"]
             proxy.data["families"] = data.get("families", [])
@@ -1031,13 +1032,13 @@ class Controller(QtCore.QObject):
             """Remove instance"""
             instance_ids = set([i.id for i in ctx])
             instance_ids.add(ctx.id)
-            for _id, item in items.items():
-                if _id not in instance_ids:
+            for id, item in items.items():
+                if id not in instance_ids:
                     # Remove from model
                     self.data["models"]["item"].remove_instance(item)
                     # Mark as removed, for instance proxies that currently
                     # being iterated in primary iterator
-                    self.data["removed"].add(_id)
+                    self.data["removed"].add(id)
 
         def on_finished(message=None):
             """Locally running function"""

--- a/pyblish_qml/control.py
+++ b/pyblish_qml/control.py
@@ -1036,11 +1036,15 @@ class Controller(QtCore.QObject):
             proxy.data["families"] = data.get("families", [])
 
         def remove_instance(ctx, items):
-            ctx_ids = set([i.id for i in ctx])
-            ctx_ids.add(ctx.id)
+            """Remove instance"""
+            instance_ids = set([i.id for i in ctx])
+            instance_ids.add(ctx.id)
             for _id, item in items.items():
-                if _id not in ctx_ids:
+                if _id not in instance_ids:
+                    # Remove from model
                     self.data["models"]["item"].remove_instance(item)
+                    # Mark as removed, for instance proxies that currently
+                    # being iterated in primary iterator
                     self.data["removed"].add(_id)
 
         def on_finished(message=None):

--- a/pyblish_qml/control.py
+++ b/pyblish_qml/control.py
@@ -1011,7 +1011,8 @@ class Controller(QtCore.QObject):
                 context.append(instance)
                 self.data["models"]["item"].add_instance(instance.to_json())
 
-            remove_instance(ctx, instance_items)
+            if len(ctx) < self.data["models"]["item"].instance_count():
+                remove_instance(ctx, instance_items)
 
             util.async(lambda: next(iterator), callback=on_next)
 

--- a/pyblish_qml/control.py
+++ b/pyblish_qml/control.py
@@ -1021,6 +1021,7 @@ class Controller(QtCore.QObject):
             # Update instance item model data for GUI
             item.isToggled = data.get("publish", True)
             item.optional = data.get("optional", True)
+            item.category = data.get("category", data["family"])
 
             families = [data["family"]]
             families.extend(data.get("families", []))

--- a/pyblish_qml/control.py
+++ b/pyblish_qml/control.py
@@ -340,7 +340,9 @@ class Controller(QtCore.QObject):
 
         for plug, instance in iterator(plugins, context):
 
-            if instance is not None and instance.id in self.data["removed"]:
+            if (instance is not None and
+                    (instance.id in self.data["removed"] or
+                     not instance.data.get("publish", True))):
                 continue
 
             state["nextOrder"] = plug.order
@@ -997,8 +999,11 @@ class Controller(QtCore.QObject):
         def update_context(ctx):
             instance_items = {item.id: item for item in
                               self.data["models"]["item"].instances}
-            for instance in ctx:
+            for index, instance in enumerate(ctx):
                 if instance.id in instance_items:
+                    # Update instance proxy data
+                    context[index].data.update(instance.data)
+                    # Update instance item model data
                     item = instance_items[instance.id]
                     update_instance(item, instance.data)
                     continue

--- a/pyblish_qml/control.py
+++ b/pyblish_qml/control.py
@@ -991,20 +991,32 @@ class Controller(QtCore.QObject):
 
             self.data["models"]["item"].update_with_result(result)
             self.data["models"]["result"].update_with_result(result)
+            update_instance_with_result(result)
 
             # Once the main thread has finished updating
             # the GUI, we can proceed handling of next task.
             util.async(self.host.context, callback=update_context)
 
+        def update_instance_with_result(result):
+            id = (result["instance"] or {}).get("id")
+            data = (result["instance"] or {}).get("data")
+            if id is None or data is None:
+                return
+
+            proxy = next((i for i in context if i.id == id), None)
+            if proxy is None:
+                return
+            # Update proxy instance data which currently being iterated in
+            # the primary iterator
+            proxy.data["publish"] = data.get("publish", True)
+            proxy.data["family"] = data["family"]
+            proxy.data["families"] = data.get("families", [])
+
         def update_context(ctx):
             item_model = self.data["models"]["item"]
             instance_items = {item.id: item for item in item_model.instances}
             for instance in ctx:
-                _id = instance.id
-                if _id in instance_items:
-                    item = instance_items[_id]
-                    proxy = next((i for i in context if i.id == _id), None)
-                    update_instance(item, proxy, instance.data)
+                if instance.id in instance_items:
                     continue
 
                 context.append(instance)
@@ -1014,26 +1026,6 @@ class Controller(QtCore.QObject):
                 remove_instance(ctx, instance_items)
 
             util.async(lambda: next(iterator), callback=on_next)
-
-        def update_instance(item, proxy, data):
-            """Update model and proxy for reflecting changes on instance"""
-
-            # Update instance item model data for GUI
-            item.isToggled = data.get("publish", True)
-            item.optional = data.get("optional", True)
-            item.category = data.get("category", data["family"])
-
-            families = [data["family"]]
-            families.extend(data.get("families", []))
-            item.familiesConcatenated = ", ".join(families)
-
-            if proxy is None:
-                return
-            # Update proxy instance data which currently being iterated in
-            # the primary iterator
-            proxy.data["publish"] = data.get("publish", True)
-            proxy.data["family"] = data["family"]
-            proxy.data["families"] = data.get("families", [])
 
         def remove_instance(ctx, items):
             """Remove instance"""

--- a/pyblish_qml/control.py
+++ b/pyblish_qml/control.py
@@ -991,15 +991,27 @@ class Controller(QtCore.QObject):
             util.async(self.host.context, callback=update_context)
 
         def update_context(ctx):
-            instances = [i.id for i in self.data["models"]["item"].instances]
+            instance_items = {item.id: item for item in
+                              self.data["models"]["item"].instances}
             for instance in ctx:
-                if instance.id in instances:
+                if instance.id in instance_items:
+                    item = instance_items[instance.id]
+                    update_instance(item, instance.data)
                     continue
 
                 context.append(instance)
                 self.data["models"]["item"].add_instance(instance.to_json())
 
             util.async(lambda: next(iterator), callback=on_next)
+
+        def update_instance(item, data):
+            """Update model for reflecting changes on instance"""
+            item.isToggled = data.get("publish", True)
+            item.optional = data.get("optional", True)
+
+            families = [data["family"]]
+            families.extend(data.get("families", []))
+            item.familiesConcatenated = ", ".join(families)
 
         def on_finished(message=None):
             """Locally running function"""

--- a/pyblish_qml/control.py
+++ b/pyblish_qml/control.py
@@ -999,10 +999,8 @@ class Controller(QtCore.QObject):
         def update_context(ctx):
             item_model = self.data["models"]["item"]
             instance_items = {item.id: item for item in item_model.instances}
-            for index, instance in enumerate(ctx):
+            for instance in ctx:
                 if instance.id in instance_items:
-                    # Update instance proxy data
-                    context[index].data.update(instance.data)
                     # Update instance item model data
                     item = instance_items[instance.id]
                     update_instance(item, instance.data)
@@ -1024,6 +1022,12 @@ class Controller(QtCore.QObject):
             families = [data["family"]]
             families.extend(data.get("families", []))
             item.familiesConcatenated = ", ".join(families)
+
+            # Update instance proxy data
+            for instance_proxy in context:
+                if instance_proxy.id == item.id:
+                    instance_proxy.data["publish"] = data.get("publish", True)
+                    break
 
         def remove_instance(ctx, items):
             ctx_ids = set([i.id for i in ctx])

--- a/pyblish_qml/control.py
+++ b/pyblish_qml/control.py
@@ -997,8 +997,8 @@ class Controller(QtCore.QObject):
             util.async(self.host.context, callback=update_context)
 
         def update_context(ctx):
-            instance_items = {item.id: item for item in
-                              self.data["models"]["item"].instances}
+            item_model = self.data["models"]["item"]
+            instance_items = {item.id: item for item in item_model.instances}
             for index, instance in enumerate(ctx):
                 if instance.id in instance_items:
                     # Update instance proxy data
@@ -1009,9 +1009,9 @@ class Controller(QtCore.QObject):
                     continue
 
                 context.append(instance)
-                self.data["models"]["item"].add_instance(instance.to_json())
+                item_model.add_instance(instance.to_json())
 
-            if len(ctx) < self.data["models"]["item"].instance_count():
+            if len(ctx) < item_model.instance_count():
                 remove_instance(ctx, instance_items)
 
             util.async(lambda: next(iterator), callback=on_next)

--- a/pyblish_qml/control.py
+++ b/pyblish_qml/control.py
@@ -1030,8 +1030,7 @@ class Controller(QtCore.QObject):
             ctx_ids.add(ctx.id)
             for _id, item in items.items():
                 if _id not in ctx_ids:
-                    self.data["models"]["item"].instances.remove(item)
-                    self.data["models"]["item"].items.remove(item)
+                    self.data["models"]["item"].remove_instance(item)
                     self.data["removed"].add(_id)
 
         def on_finished(message=None):

--- a/pyblish_qml/control.py
+++ b/pyblish_qml/control.py
@@ -70,7 +70,6 @@ class Controller(QtCore.QObject):
         self.targets = targets
 
         self.data = {
-            "removed": set(),
             "models": {
                 "item": models.ItemModel(),
                 "result": models.ResultModel(),
@@ -340,9 +339,7 @@ class Controller(QtCore.QObject):
 
         for plug, instance in iterator(plugins, context):
 
-            if (instance is not None and
-                    (instance.id in self.data["removed"] or
-                     not instance.data.get("publish", True))):
+            if instance is not None and not instance.data.get("publish", True):
                 continue
 
             state["nextOrder"] = plug.order
@@ -1042,15 +1039,15 @@ class Controller(QtCore.QObject):
 
         def remove_instance(ctx, items):
             """Remove instance"""
-            instance_ids = set([i.id for i in ctx])
+            instances = {i.id: i for i in context}
+            instance_ids = set(i.id for i in ctx)
             instance_ids.add(ctx.id)
             for id, item in items.items():
                 if id not in instance_ids:
                     # Remove from model
                     self.data["models"]["item"].remove_instance(item)
-                    # Mark as removed, for instance proxies that currently
-                    # being iterated in primary iterator
-                    self.data["removed"].add(id)
+                    # Remove instance from list
+                    context.remove(instances[id])
 
         def on_finished(message=None):
             """Locally running function"""

--- a/pyblish_qml/ipc/server.py
+++ b/pyblish_qml/ipc/server.py
@@ -216,6 +216,8 @@ class Server(object):
 
         def _listen():
             """This runs in a thread"""
+            HEADER = "pyblish-qml:popen.request"
+
             for line in iter(self.popen.stdout.readline, b""):
 
                 if six.PY3:
@@ -229,7 +231,9 @@ class Server(object):
                     sys.stdout.write(line)
 
                 else:
-                    if response.get("header") == "pyblish-qml:popen.request":
+                    if (hasattr(response, "get") and
+                            response.get("header") == HEADER):
+
                         payload = response["payload"]
                         args = payload["args"]
 

--- a/pyblish_qml/models.py
+++ b/pyblish_qml/models.py
@@ -275,6 +275,12 @@ class ItemModel(AbstractModel):
         self.instances = util.ItemList(key="id")
         self.sections = util.ItemList(key="id")
 
+    def instance_count(self):
+        """Return the number of `instance` in model"""
+        item_count = len(self.instances)
+        # The first item in `self.instances` is `context`
+        return 0 if item_count < 0 else item_count - 1
+
     def reorder(self, context):
         # Reorder instances in support of "cooperative collection"
         self.beginResetModel()

--- a/pyblish_qml/models.py
+++ b/pyblish_qml/models.py
@@ -519,6 +519,19 @@ class ItemModel(AbstractModel):
             item.duration += result["duration"]
             item.finishedAt = time.time()
 
+            if item.itemType == "instance":
+                # Update instance GUI related data
+                data = (result["instance"] or {}).get("data")
+                if data is not None:
+
+                    item.isToggled = data.get("publish", True)
+                    item.optional = data.get("optional", True)
+                    item.category = data.get("category", data["family"])
+
+                    families = [data["family"]]
+                    families.extend(data.get("families", []))
+                    item.familiesConcatenated = ", ".join(families)
+
             if item.itemType == "plugin" and not item.actionsIconVisible:
 
                 actions = list(item.actions)

--- a/pyblish_qml/models.py
+++ b/pyblish_qml/models.py
@@ -519,19 +519,6 @@ class ItemModel(AbstractModel):
             item.duration += result["duration"]
             item.finishedAt = time.time()
 
-            if item.itemType == "instance":
-                # Update instance GUI related data
-                data = (result["instance"] or {}).get("data")
-                if data is not None:
-
-                    item.isToggled = data.get("publish", True)
-                    item.optional = data.get("optional", True)
-                    item.category = data.get("category", data["family"])
-
-                    families = [data["family"]]
-                    families.extend(data.get("families", []))
-                    item.familiesConcatenated = ", ".join(families)
-
             if item.itemType == "plugin" and not item.actionsIconVisible:
 
                 actions = list(item.actions)

--- a/pyblish_qml/models.py
+++ b/pyblish_qml/models.py
@@ -224,6 +224,13 @@ class AbstractModel(QtCore.QAbstractListModel):
 
         return item
 
+    def remove_item(self, item):
+        """Remove item from model"""
+        index = self.items.index(item)
+        self.beginRemoveRows(QtCore.QModelIndex(), index, index)
+        self.items.remove(item)
+        self.endRemoveRows()
+
     def _dataChanged(self, item):
         """Explicitly emit dataChanged upon item changing"""
         index = self.items.index(item)
@@ -404,6 +411,11 @@ class ItemModel(AbstractModel):
 
         item = self.add_item(item)
         self.instances.append(item)
+
+    def remove_instance(self, item):
+        """Remove `instance` from model"""
+        self.instances.remove(item)
+        self.remove_item(item)
 
     def add_section(self, name):
         """Append `section` to model

--- a/pyblish_qml/version.py
+++ b/pyblish_qml/version.py
@@ -1,7 +1,7 @@
 
 VERSION_MAJOR = 1
 VERSION_MINOR = 9
-VERSION_PATCH = 5
+VERSION_PATCH = 8
 
 version_info = (VERSION_MAJOR, VERSION_MINOR, VERSION_PATCH)
 version = '%i.%i.%i' % version_info


### PR DESCRIPTION
The implementation of #315, which aim to keep the GUI to display the latest status data change of instances, like `optional`, `publish`, `families`.

Currently, once the plugin which responsible to create the instance, has been processed, the change of the instance data that made by other plugins will not reflected to GUI. For example, the newly added family will not be shown in Perspective View, and setting `publish` to False will not toggle instance off.

Not good to merge yet.
