### PR TITLE
Ensure pulse thread is created before we start listening

### DIFF
--- a/pyblish_qml/ipc/server.py
+++ b/pyblish_qml/ipc/server.py
@@ -267,14 +267,14 @@ class Server(object):
                         sys.stdout.write(line)
 
         if not self.listening:
+            self._start_pulse()
+
             if self.modal:
                 _listen()
             else:
                 thread = threading.Thread(target=_listen)
                 thread.daemon = True
                 thread.start()
-
-            self._start_pulse()
 
             self.listening = True
 

--- a/pyblish_qml/version.py
+++ b/pyblish_qml/version.py
@@ -1,7 +1,7 @@
 
 VERSION_MAJOR = 1
 VERSION_MINOR = 9
-VERSION_PATCH = 1
+VERSION_PATCH = 2
 
 version_info = (VERSION_MAJOR, VERSION_MINOR, VERSION_PATCH)
 version = '%i.%i.%i' % version_info


### PR DESCRIPTION
### Problem
While working on a modal pyblisher, I encountered an issue where the QML client closed itself with no return code after 15 seconds.

After investigation, it seem the cause of the issue is that the pulse thread (which notify the client that the server is still alive) is created after the main logic thread. If the pyblisher is modal, the main logic is not a thread and hence will prevent the pulse thread from being created in time. 

This issue can be easily reproduced by opening a modal pyblisher in any host with pyblish_qml-1.9.0+.

### Solution
This PR move the creation of the pulse thread before the main logic.