### PR TITLE
No Qt

### DIFF
--- a/pyblish_qml/ipc/server.py
+++ b/pyblish_qml/ipc/server.py
@@ -353,7 +353,9 @@ def find_pyqt5(python):
                 python, "-c",
                 "import PyQt5, sys;"
                 "sys.stdout.write(PyQt5.__file__)"
-            ])
+
+                # Normally, the output is bytes.
+            ], universal_newlines=True)
 
             pyqt5 = os.path.dirname(path)
 

--- a/pyblish_qml/ipc/server.py
+++ b/pyblish_qml/ipc/server.py
@@ -343,6 +343,23 @@ def find_pyqt5(python):
         os.getenv("PYBLISH_QML_PYQT5")
     )
 
+    # If not registered, ask Python for it explicitly
+    # This avoids having to expose PyQt5 on PYTHONPATH
+    # where it may otherwise get picked up by bystanders
+    # such as Python 2.
+    if not pyqt5:
+        try:
+            path = subprocess.check_output([
+                python, "-c",
+                "import PyQt5, sys;"
+                "sys.stdout.write(PyQt5.__file__)"
+            ])
+
+            pyqt5 = os.path.dirname(path)
+
+        except subprocess.CalledProcessError:
+            pass
+
     return pyqt5
 
 


### PR DESCRIPTION
This PR removes the Qt dependency from a host, such that only the external Python process requires it.

Before, Qt was imported regardless of host, to try and show a splash screen, install an event filter and listen on the application quit signal. Now that only happens if Qt is available.

The Qt import mechanism itself was moved into a closed scope, such that it leaves mock-functions available for hosts that lack access to Qt. The result is no loss in functionality, and no need for PyQt5 to exist from a given host. Now all you need is love. And Python.