### PR TITLE
Blender Support

### DIFF
--- a/pyblish_qml/ipc/server.py
+++ b/pyblish_qml/ipc/server.py
@@ -353,7 +353,9 @@ def find_pyqt5(python):
                 python, "-c",
                 "import PyQt5, sys;"
                 "sys.stdout.write(PyQt5.__file__)"
-            ])
+
+                # Normally, the output is bytes.
+            ], universal_newlines=True)
 
             pyqt5 = os.path.dirname(path)
 

--- a/pyblish_qml/ipc/server.py
+++ b/pyblish_qml/ipc/server.py
@@ -343,6 +343,23 @@ def find_pyqt5(python):
         os.getenv("PYBLISH_QML_PYQT5")
     )
 
+    # If not registered, ask Python for it explicitly
+    # This avoids having to expose PyQt5 on PYTHONPATH
+    # where it may otherwise get picked up by bystanders
+    # such as Python 2.
+    if not pyqt5:
+        try:
+            path = subprocess.check_output([
+                python, "-c",
+                "import PyQt5, sys;"
+                "sys.stdout.write(PyQt5.__file__)"
+            ])
+
+            pyqt5 = os.path.dirname(path)
+
+        except subprocess.CalledProcessError:
+            pass
+
     return pyqt5
 
 

--- a/pyblish_qml/version.py
+++ b/pyblish_qml/version.py
@@ -1,7 +1,7 @@
 
 VERSION_MAJOR = 1
 VERSION_MINOR = 9
-VERSION_PATCH = 3
+VERSION_PATCH = 4
 
 version_info = (VERSION_MAJOR, VERSION_MINOR, VERSION_PATCH)
 version = '%i.%i.%i' % version_info


### PR DESCRIPTION
Building upon #320, this PR adds support for Blender.

The trick here is passing data between threads using a native Queue. A polling operator is added to Blender, which continuously polls a queue for things to do. When QML has a task for Blender, it's added to this queue, Blender runs it, and adds to another queue for QML to pick up the result.

It's currently running at 10 ms intervals, including when the GUI isn't visible, which isn't ideal and could be optimised away. E.g. stop polling when GUI is closed.