### PR TITLE
Windows Bug Fixes

### DIFF
--- a/pyblish_qml/host.py
+++ b/pyblish_qml/host.py
@@ -268,7 +268,7 @@ class QtHost(Host):
         }
 
         class EventFilter(QtCore.QObject):
-            def eventFilter(self, widget, event):
+            def eventFilter(this, widget, event):
                 try:
                     func_name = {
                         QtCore.QEvent.Show: "rise",

--- a/pyblish_qml/ipc/server.py
+++ b/pyblish_qml/ipc/server.py
@@ -357,7 +357,7 @@ def find_pyqt5(python):
                 # Normally, the output is bytes.
             ], universal_newlines=True)
 
-            pyqt5 = os.path.dirname(path)
+            pyqt5 = os.path.dirname(os.path.dirname(path))
 
         except subprocess.CalledProcessError:
             pass

--- a/pyblish_qml/version.py
+++ b/pyblish_qml/version.py
@@ -1,7 +1,7 @@
 
 VERSION_MAJOR = 1
 VERSION_MINOR = 9
-VERSION_PATCH = 4
+VERSION_PATCH = 5
 
 version_info = (VERSION_MAJOR, VERSION_MINOR, VERSION_PATCH)
 version = '%i.%i.%i' % version_info


### PR DESCRIPTION
Without `PYBLISH_QML_PYQT5`, the wrong path got automatically registered causing Qt binaries to be exposed to the Pyblish QML process (e.g. PySide2 binaries for a PyQt5 application).

Also when the above error occurred, the event filter was supposed to get uninstalled, but was not. That's fixed here too.