### PR TITLE
Always try to install on show

### DIFF
--- a/pyblish_qml/host.py
+++ b/pyblish_qml/host.py
@@ -93,8 +93,7 @@ def show(parent=None, targets=[], modal=None):
         modal = bool(os.environ.get("PYBLISH_QML_MODAL", False))
 
     # Automatically install if not already installed.
-    if not _state.get("installed"):
-        install(modal)
+    install(modal)
 
     # Show existing GUI
     if _state.get("currentServer"):


### PR DESCRIPTION
### Bug fix
This fixes the bug that QML only install eventFilter once on first run :)
(Missed this one because I only tried running it once in Maya while testing previous PR)