### PR TITLE
Fix occasional ipc deadlock

### DIFF
--- a/pyblish_qml/ipc/client.py
+++ b/pyblish_qml/ipc/client.py
@@ -155,7 +155,7 @@ class Proxy(object):
         assert self.channels["response"].empty(), (
             "There were pending messages in the response channel")
 
-        sys.stdout.write(data + "\n")
+        sys.stdout.write("\n" + data + "\n")
         sys.stdout.flush()
 
         try:

--- a/pyblish_qml/ipc/client.py
+++ b/pyblish_qml/ipc/client.py
@@ -155,9 +155,10 @@ class Proxy(object):
         assert self.channels["response"].empty(), (
             "There were pending messages in the response channel")
         
-        sys.stdout.write("\n")
-        sys.stdout.write(data)
-        sys.stdout.write("\n")
+        # To ensure successful IPC message parsing, the message and the
+        # surrounding delimiters must be passed to the stream object at once.
+        # See https://github.com/pyblish/pyblish-qml/pull/325 for more info.
+        sys.stdout.write("\n" + data + "\n")
         sys.stdout.flush()
 
         try:

--- a/pyblish_qml/ipc/client.py
+++ b/pyblish_qml/ipc/client.py
@@ -154,8 +154,10 @@ class Proxy(object):
         # Both scenarios are bugs.
         assert self.channels["response"].empty(), (
             "There were pending messages in the response channel")
-
-        sys.stdout.write("\n" + data + "\n")
+        
+        sys.stdout.write("\n")
+        sys.stdout.write(data)
+        sys.stdout.write("\n")
         sys.stdout.flush()
 
         try:

--- a/pyblish_qml/version.py
+++ b/pyblish_qml/version.py
@@ -1,7 +1,7 @@
 
 VERSION_MAJOR = 1
 VERSION_MINOR = 9
-VERSION_PATCH = 5
+VERSION_PATCH = 6
 
 version_info = (VERSION_MAJOR, VERSION_MINOR, VERSION_PATCH)
 version = '%i.%i.%i' % version_info


### PR DESCRIPTION
Depending on when threads print to stdout, there is a chance that the IPC gets stuck forever. The easiest explanation/demo is the following:
```
import sys
import threading
import time

def ipc_communication_thread():
    while True:
        msg = '{"json": "yes"}'
        sys.stdout.write(msg + "\n")
        sys.stdout.flush()

def anything_else():
    while True:
        print "logging something"

t0 = threading.Thread(target=ipc_communication_thread)
t0.daemon = True
t1 = threading.Thread(target=anything_else)
t1.daemon = True

t0.start()
t1.start()

time.sleep(2)
```
Looking at the output the problem is readily apparent:
> ...
> {"json": "yes"}
> logging something{"json": "yes"}
> 
> logging something{"json": "yes"}
> 
> logging something{"json": "yes"}
> 
> {"json": "yes"}
> logging something
> {"json": "yes"}
> ...

The `print` does not put its content into the stdout stream in an atomic fashion. Sometimes the newline lags behind just enough to allow the other thread to insert its own message into the stream. With the current setup of the IPC message parsing this means that message is not picked up and is lost forever.

This would also happen if some module logged/printed some bytes without newline endings.

Luckily the fix is easy as pie. By enclosing the message body with newline characters it will surely be picked up by the IPC parser.

I'm curious. Why are we using sdtin/out streams for communication instead of sockets for example?