### PR TITLE
Some QoL features for integration

### DIFF
--- a/pyblish_qml/__init__.py
+++ b/pyblish_qml/__init__.py
@@ -5,7 +5,7 @@ from .version import (
 )
 
 
-def show(parent=None, targets=None, modal=None, foster=None):
+def show(parent=None, targets=None, modal=None, foster=None, comment=None, auto_publish_at_first_run=False):
     from . import host
 
     if foster is not None:
@@ -13,7 +13,7 @@ def show(parent=None, targets=None, modal=None, foster=None):
 
     if targets is None:
         targets = []
-    return host.show(parent, targets, modal)
+    return host.show(parent, targets, modal, comment, auto_publish_at_first_run)
 
 
 _state = {}

--- a/pyblish_qml/__init__.py
+++ b/pyblish_qml/__init__.py
@@ -5,7 +5,7 @@ from .version import (
 )
 
 
-def show(parent=None, targets=None, modal=None, foster=None, comment=None, auto_publish_at_first_run=False):
+def show(parent=None, targets=None, modal=None, foster=None, auto_publish=False, auto_validate=False):
     from . import host
 
     if foster is not None:
@@ -13,7 +13,7 @@ def show(parent=None, targets=None, modal=None, foster=None, comment=None, auto_
 
     if targets is None:
         targets = []
-    return host.show(parent, targets, modal, comment, auto_publish_at_first_run)
+    return host.show(parent, targets, modal, auto_publish, auto_validate)
 
 
 _state = {}

--- a/pyblish_qml/app.py
+++ b/pyblish_qml/app.py
@@ -181,6 +181,10 @@ class Application(QtGui.QGuiApplication):
 
             util.timer_end("ready", "Awaited statemachine for %.2f ms")
 
+        if client_settings:
+            self.controller.data['comment'] = client_settings['comment'] if client_settings.get('comment') else ''
+            self.controller.data['autoPublishAtFirstRun'] = client_settings.get('autoPublishAtFirstRun', False)
+
         self.controller.show.emit()
 
         # Allow time for QML to initialise

--- a/pyblish_qml/app.py
+++ b/pyblish_qml/app.py
@@ -182,8 +182,8 @@ class Application(QtGui.QGuiApplication):
             util.timer_end("ready", "Awaited statemachine for %.2f ms")
 
         if client_settings:
-            self.controller.data['comment'] = client_settings['comment'] if client_settings.get('comment') else ''
-            self.controller.data['autoPublishAtFirstRun'] = client_settings.get('autoPublishAtFirstRun', False)
+            self.controller.data['autoValidate'] = client_settings.get('autoValidate', False)
+            self.controller.data['autoPublish'] = client_settings.get('autoPublish', False)
 
         self.controller.show.emit()
 

--- a/pyblish_qml/control.py
+++ b/pyblish_qml/control.py
@@ -817,9 +817,14 @@ class Controller(QtCore.QObject):
                 if section.name in settings.HiddenSections:
                     self.hideSection(True, section.name)
 
-            if first_run and self.data.get('autoPublishAtFirstRun'):
-                print("Starting auto-publish at first run..")
-                util.schedule(self.publish, 1)
+            # Run selected procedure on first run
+            if first_run:
+                if self.data.get('autoPublish'):
+                    print("Starting auto-publish at first run..")
+                    util.schedule(self.publish, 1)
+                elif self.data.get('autoValidate'):
+                    print("Starting auto-validate at first run..")
+                    util.schedule(self.validate, 1)
 
         def on_run(plugins):
             """Fetch instances in their current state, right after reset"""

--- a/pyblish_qml/control.py
+++ b/pyblish_qml/control.py
@@ -805,7 +805,8 @@ class Controller(QtCore.QObject):
             # Notify subscribers of the comment
             self.comment_sync(comment)
 
-            if self.data["firstRun"]:
+            first_run = self.data["firstRun"]
+            if first_run:
                 self.firstRun.emit()
                 self.data["firstRun"] = False
 
@@ -815,6 +816,10 @@ class Controller(QtCore.QObject):
             for section in self.data["models"]["item"].sections:
                 if section.name in settings.HiddenSections:
                     self.hideSection(True, section.name)
+
+            if first_run and self.data.get('autoPublishAtFirstRun'):
+                print("Starting auto-publish at first run..")
+                util.schedule(self.publish, 1)
 
         def on_run(plugins):
             """Fetch instances in their current state, right after reset"""

--- a/pyblish_qml/host.py
+++ b/pyblish_qml/host.py
@@ -75,7 +75,7 @@ def uninstall():
     sys.stdout.write("Pyblish QML shutdown successful.\n")
 
 
-def show(parent=None, targets=[], modal=None):
+def show(parent=None, targets=[], modal=None, comment=None, auto_publish_at_first_run=False):
     """Attempt to show GUI
 
     Requires install() to have been run first, and
@@ -95,13 +95,17 @@ def show(parent=None, targets=[], modal=None):
     # Automatically install if not already installed.
     install(modal)
 
+    show_settings = settings.to_dict()
+    show_settings['comment'] = comment
+    show_settings['autoPublishAtFirstRun'] = auto_publish_at_first_run
+
     # Show existing GUI
     if _state.get("currentServer"):
         server = _state["currentServer"]
         proxy = ipc.server.Proxy(server)
 
         try:
-            proxy.show(settings.to_dict())
+            proxy.show(show_settings)
             return server
 
         except IOError:
@@ -120,7 +124,7 @@ def show(parent=None, targets=[], modal=None):
         return host.desplash()
 
     proxy = ipc.server.Proxy(server)
-    proxy.show(settings.to_dict())
+    proxy.show(show_settings)
 
     # Store reference to server for future calls
     _state["currentServer"] = server
@@ -154,6 +158,32 @@ def validate():
 
         try:
             proxy.validate()
+        except IOError:
+            # The running instance has already been closed.
+            _state.pop("currentServer")
+
+            
+def hide():
+    # get existing GUI
+    if _state.get("currentServer"):
+        server = _state["currentServer"]
+        proxy = ipc.server.Proxy(server)
+
+        try:
+            proxy.hide()
+        except IOError:
+            # The running instance has already been closed.
+            _state.pop("currentServer")
+
+
+def quit():
+    # get existing GUI
+    if _state.get("currentServer"):
+        server = _state["currentServer"]
+        proxy = ipc.server.Proxy(server)
+
+        try:
+            proxy.quit()
         except IOError:
             # The running instance has already been closed.
             _state.pop("currentServer")

--- a/pyblish_qml/host.py
+++ b/pyblish_qml/host.py
@@ -75,7 +75,7 @@ def uninstall():
     sys.stdout.write("Pyblish QML shutdown successful.\n")
 
 
-def show(parent=None, targets=[], modal=None, comment=None, auto_publish_at_first_run=False):
+def show(parent=None, targets=[], modal=None, auto_publish=False, auto_validate=False):
     """Attempt to show GUI
 
     Requires install() to have been run first, and
@@ -96,8 +96,8 @@ def show(parent=None, targets=[], modal=None, comment=None, auto_publish_at_firs
     install(modal)
 
     show_settings = settings.to_dict()
-    show_settings['comment'] = comment
-    show_settings['autoPublishAtFirstRun'] = auto_publish_at_first_run
+    show_settings['autoPublish'] = auto_publish
+    show_settings['autoValidate'] = auto_validate
 
     # Show existing GUI
     if _state.get("currentServer"):

--- a/pyblish_qml/version.py
+++ b/pyblish_qml/version.py
@@ -1,7 +1,7 @@
 
 VERSION_MAJOR = 1
 VERSION_MINOR = 9
-VERSION_PATCH = 8
+VERSION_PATCH = 9
 
 version_info = (VERSION_MAJOR, VERSION_MINOR, VERSION_PATCH)
 version = '%i.%i.%i' % version_info


### PR DESCRIPTION
These are some features to streamline the usage of pyblish-qml in our pipeline. They are implemented backwards compatible,  no previous usage/behaviour is expected to break.

Basically we have our own UI that deals with all the instance/plugin config. This means when we call the pyblish-qml app, everything is already set up. Our changes are related to automation:

1. One of the added features is a new argument to `show(... , auto_publish_at_first_run=False)`. This saves the user the wait for the reset and the click on the publish button.

1. Another added feature is also a new argument to `show(... , comment=None)`. In our system the user needs to input the comment earlier than the pyblish process can be started, so we wish to be able to pass it along to pyblish-qml.

1. Lastly, two API entry points were added: `host.hide` and `host.quit`. These were available on the `Proxy` object but they were not readily accessible like `host.publish` or `host.validate`. We use these to automatically exit the UI if all processes succeed.