### PR TITLE
Re-apply #325 and fix #327

### DIFF
--- a/pyblish_qml/ipc/client.py
+++ b/pyblish_qml/ipc/client.py
@@ -168,7 +168,10 @@ class Proxy(object):
         assert self.channels["response"].empty(), (
             "There were pending messages in the response channel")
 
-        sys.stdout.write(data + "\n")
+        # To ensure successful IPC message parsing, the message and the
+        # surrounding delimiters must be passed to the stream object at once.
+        # See https://github.com/pyblish/pyblish-qml/pull/325 for more info.
+        sys.stdout.write("\n" + data + "\n")
         sys.stdout.flush()
 
         try:

--- a/pyblish_qml/ipc/server.py
+++ b/pyblish_qml/ipc/server.py
@@ -260,8 +260,6 @@ class Server(object):
                         sys.stdout.write(line)
 
                 else:
-                    # last newline was the preamble for a real message
-                    last_msg_newline = False
 
                     if (hasattr(response, "get") and
                             response.get("header") == HEADER):
@@ -300,7 +298,13 @@ class Server(object):
                         # In the off chance that a message
                         # was successfully decoded as JSON,
                         # but *wasn't* a request, just print it.
+                        if last_msg_newline:
+                            # last newline message was a real newline
+                            sys.stdout.write("\n")
                         sys.stdout.write(line)
+
+                    # Last newline has been handled at this point.
+                    last_msg_newline = False
 
         if not self.listening:
             self._start_pulse()

--- a/pyblish_qml/ipc/server.py
+++ b/pyblish_qml/ipc/server.py
@@ -233,6 +233,11 @@ class Server(object):
         def _listen():
             """This runs in a thread"""
             HEADER = "pyblish-qml:popen.request"
+            
+            # To ensure successful IPC message parsing, the message got a delimiter newline in front
+            # of it. To differentiate between real newlines and message preambles we need to buffer
+            # them until the next part arrives.
+            last_msg_newline = False
 
             for line in iter(self.popen.stdout.readline, b""):
 
@@ -241,12 +246,23 @@ class Server(object):
 
                 try:
                     response = json.loads(line)
-
                 except Exception:
-                    # This must be a regular message.
-                    sys.stdout.write(line)
+                    if last_msg_newline:
+                        # last newline message was a real newline
+                        sys.stdout.write("\n")
+                        last_msg_newline = False
+
+                    if line == "\n":
+                        # buffer and print newlines only if they are not preambles of messages
+                        last_msg_newline = True
+                    else:
+                        # This must be a regular message.
+                        sys.stdout.write(line)
 
                 else:
+                    # last newline was the preamble for a real message
+                    last_msg_newline = False
+
                     if (hasattr(response, "get") and
                             response.get("header") == HEADER):
 

--- a/pyblish_qml/version.py
+++ b/pyblish_qml/version.py
@@ -1,7 +1,7 @@
 
 VERSION_MAJOR = 1
 VERSION_MINOR = 9
-VERSION_PATCH = 9
+VERSION_PATCH = 10
 
 version_info = (VERSION_MAJOR, VERSION_MINOR, VERSION_PATCH)
 version = '%i.%i.%i' % version_info


### PR DESCRIPTION
This contains a fix for #327 while re-applying #325 .

The async consumption of a sync queue discovered during the investigation of #327 is a separate problem:

- This fix ensures different threads on the client side that print will not mess up the communication.
- While the async consumption of messages is a design issue where two legitimate communication procedures may encounter a race condition.

I propose that a new issue should be opened for the async problem.