### PR TITLE
WindowsError raised in Houdini after #320

### DIFF
--- a/pyblish_qml/ipc/server.py
+++ b/pyblish_qml/ipc/server.py
@@ -399,7 +399,6 @@ def find_pyqt5(python):
                 ],
                 universal_newlines=True,  # Normally, the output is bytes.
                 stdin=subprocess.PIPE,
-                env={"SYSTEMROOT": os.getenv("SYSTEMROOT"), "PATH": ""},
                 creationflags=CREATE_NO_WINDOW)
 
             pyqt5 = os.path.dirname(os.path.dirname(path))

--- a/pyblish_qml/ipc/server.py
+++ b/pyblish_qml/ipc/server.py
@@ -397,7 +397,7 @@ def find_pyqt5(python):
                 "sys.stdout.write(PyQt5.__file__)"
 
                 # Normally, the output is bytes.
-            ], universal_newlines=True)
+            ], universal_newlines=True, stdin=subprocess.PIPE)
 
             pyqt5 = os.path.dirname(os.path.dirname(path))
 

--- a/pyblish_qml/ipc/server.py
+++ b/pyblish_qml/ipc/server.py
@@ -391,13 +391,16 @@ def find_pyqt5(python):
     # such as Python 2.
     if not pyqt5:
         try:
-            path = subprocess.check_output([
-                python, "-c",
-                "import PyQt5, sys;"
-                "sys.stdout.write(PyQt5.__file__)"
-
-                # Normally, the output is bytes.
-            ], universal_newlines=True, stdin=subprocess.PIPE)
+            path = subprocess.check_output(
+                [
+                    python, "-c",
+                    "import PyQt5, sys;"
+                    "sys.stdout.write(PyQt5.__file__)"
+                ],
+                universal_newlines=True,  # Normally, the output is bytes.
+                stdin=subprocess.PIPE,
+                env={"SYSTEMROOT": os.getenv("SYSTEMROOT"), "PATH": ""},
+                creationflags=CREATE_NO_WINDOW)
 
             pyqt5 = os.path.dirname(os.path.dirname(path))
 

--- a/pyblish_qml/ipc/server.py
+++ b/pyblish_qml/ipc/server.py
@@ -401,7 +401,7 @@ def find_pyqt5(python):
 
             pyqt5 = os.path.dirname(os.path.dirname(path))
 
-        except (subprocess.CalledProcessError, WindowsError):
+        except subprocess.CalledProcessError:
             pass
 
     return pyqt5

--- a/pyblish_qml/ipc/server.py
+++ b/pyblish_qml/ipc/server.py
@@ -129,9 +129,9 @@ class Server(object):
         is_embedded = os.path.split(sys.executable)[-1].lower() != "python.exe"
 
         python = python or find_python()
-        pyqt5 = pyqt5 or find_pyqt5(python)
-
         print("Using Python @ '%s'" % python)
+
+        pyqt5 = pyqt5 or find_pyqt5(python)
         print("Using PyQt5 @ '%s'" % pyqt5)
 
         # Maintain the absolute minimum of environment variables,

--- a/pyblish_qml/ipc/server.py
+++ b/pyblish_qml/ipc/server.py
@@ -233,10 +233,11 @@ class Server(object):
         def _listen():
             """This runs in a thread"""
             HEADER = "pyblish-qml:popen.request"
-            
-            # To ensure successful IPC message parsing, the message got a delimiter newline in front
-            # of it. To differentiate between real newlines and message preambles we need to buffer
-            # them until the next part arrives.
+
+            # To ensure successful IPC message parsing, the message got a
+            # delimiter newline in front of it. To differentiate between
+            # real newlines and message preambles we need to buffer them
+            # until the next part arrives.
             last_msg_newline = False
 
             for line in iter(self.popen.stdout.readline, b""):
@@ -253,7 +254,8 @@ class Server(object):
                         last_msg_newline = False
 
                     if line == "\n":
-                        # buffer and print newlines only if they are not preambles of messages
+                        # buffer and print newlines only if they are not
+                        # preambles of messages
                         last_msg_newline = True
                     else:
                         # This must be a regular message.

--- a/pyblish_qml/ipc/server.py
+++ b/pyblish_qml/ipc/server.py
@@ -399,7 +399,7 @@ def find_pyqt5(python):
 
             pyqt5 = os.path.dirname(os.path.dirname(path))
 
-        except subprocess.CalledProcessError:
+        except (subprocess.CalledProcessError, WindowsError):
             pass
 
     return pyqt5

--- a/pyblish_qml/ipc/server.py
+++ b/pyblish_qml/ipc/server.py
@@ -385,27 +385,6 @@ def find_pyqt5(python):
         os.getenv("PYBLISH_QML_PYQT5")
     )
 
-    # If not registered, ask Python for it explicitly
-    # This avoids having to expose PyQt5 on PYTHONPATH
-    # where it may otherwise get picked up by bystanders
-    # such as Python 2.
-    if not pyqt5:
-        try:
-            path = subprocess.check_output(
-                [
-                    python, "-c",
-                    "import PyQt5, sys;"
-                    "sys.stdout.write(PyQt5.__file__)"
-                ],
-                universal_newlines=True,  # Normally, the output is bytes.
-                stdin=subprocess.PIPE,
-                creationflags=CREATE_NO_WINDOW)
-
-            pyqt5 = os.path.dirname(os.path.dirname(path))
-
-        except subprocess.CalledProcessError:
-            pass
-
     return pyqt5
 
 

--- a/pyblish_qml/version.py
+++ b/pyblish_qml/version.py
@@ -1,7 +1,7 @@
 
 VERSION_MAJOR = 1
 VERSION_MINOR = 9
-VERSION_PATCH = 10
+VERSION_PATCH = 11
 
 version_info = (VERSION_MAJOR, VERSION_MINOR, VERSION_PATCH)
 version = '%i.%i.%i' % version_info


### PR DESCRIPTION
### Problem

After PR #320, `WindowsError: [Error 6]` raised in Houdini while `PyQt5` lookup at this line [here](https://github.com/pyblish/pyblish-qml/blob/e93b144f7c0bf7ea5606e8449399d77ef4943753/pyblish_qml/ipc/server.py#L392).
I changed from using `subprocess.check_output` to `Popen` still getting same error.
It seems something to do with `subprocess.PIPE`.

### Solution

Not sure if this is the right fix, but for what I can do now is adding `WindowsError` exception.

---

### Update
The main issue was we need both `stdin` and `stdout` set to `subprocess.PIPE` in order to work inside Houdini ( without Administrator privilege ).
So here's the main changes for working in Houdini:
* Add `stdin=subprocess.PIPE`
* Run `check_output` with clean environment

