### PR TITLE
Bump ubuntu docker image version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 # cd pyblish-qml
 # docker run --rm -v $(pwd):/pyblish-qml pyblish/pyblish-qml
 
-FROM ubuntu:17.10
+FROM ubuntu:18.10
 
 MAINTAINER marcus@abstractfactory.io
 


### PR DESCRIPTION
### Problem

The Ubuntu `17.10` docker image seems dead now, so the CI keeps failing.

### Solution

Bump Ubuntu image version to `18.10` solved this issue