### PR TITLE
Fix redundant newline from #329

### DIFF
--- a/pyblish_qml/ipc/server.py
+++ b/pyblish_qml/ipc/server.py
@@ -259,7 +259,9 @@ class Server(object):
                         last_msg_newline = True
                     else:
                         # This must be a regular message.
-                        sys.stdout.write(line)
+                        line = line.strip()
+                        if line:
+                            sys.stdout.write(line + "\n")
 
                 else:
 

--- a/pyblish_qml/version.py
+++ b/pyblish_qml/version.py
@@ -1,7 +1,7 @@
 
 VERSION_MAJOR = 1
 VERSION_MINOR = 9
-VERSION_PATCH = 11
+VERSION_PATCH = 12
 
 version_info = (VERSION_MAJOR, VERSION_MINOR, VERSION_PATCH)
 version = '%i.%i.%i' % version_info


### PR DESCRIPTION
### Problem
Still getting redundant newline after #329.

### Fix
It looks like previous fix missed out to catch *regular message*, and stripping them solved the issue.
So this PR seems to be the last puzzle of #329.

