### PR TITLE
Fix: make `window` a keyword argument for Blender 2.8 compatibility

### DIFF
--- a/pyblish_qml/host.py
+++ b/pyblish_qml/host.py
@@ -656,7 +656,7 @@ def _install_blender(use_threaded_wrapper):
             # does mean having Python execute a command all the time,
             # even as the artist is working normally and is nowhere
             # near publishing anything.
-            self._timer = wm.event_timer_add(0.01, context.window)
+            self._timer = wm.event_timer_add(0.01, window=context.window)
 
             wm.modal_handler_add(self)
             return {'RUNNING_MODAL'}

--- a/pyblish_qml/version.py
+++ b/pyblish_qml/version.py
@@ -1,7 +1,7 @@
 
 VERSION_MAJOR = 1
-VERSION_MINOR = 9
-VERSION_PATCH = 12
+VERSION_MINOR = 10
+VERSION_PATCH = 0
 
 version_info = (VERSION_MAJOR, VERSION_MINOR, VERSION_PATCH)
 version = '%i.%i.%i' % version_info


### PR DESCRIPTION
So far this is the only thing I encountered that didn't work in Blender 2.80.
This simple fix should make it work in both Blender 2.79 and Blender 2.80.