### PR TITLE
Update label as it's changed in instance.data["label"]

### DIFF
--- a/pyblish_qml/control.py
+++ b/pyblish_qml/control.py
@@ -1034,6 +1034,7 @@ class Controller(QtCore.QObject):
             item.isToggled = data.get("publish", True)
             item.optional = data.get("optional", True)
             item.category = data.get("category", data["family"])
+            item.label = data.get("label", None)
 
             families = [data["family"]]
             families.extend(data.get("families", []))


### PR DESCRIPTION
This fixes the Instance's label not updating when it's changed by a Collector later in the chain. Now it will correctly update.

See:

![update_instance_label](https://user-images.githubusercontent.com/2439881/61797873-8da77e80-ae28-11e9-8d53-eee25bc8d501.gif)

Reference:

- [Pyblish Gitter Discussion about instance label not updating in Pyblish QML](https://gitter.im/pyblish/pyblish?at=5d3856a7be916e76e22b264f)