### PR TITLE
Fix #341: Ignore Categories when deciding to show Actions icon on plug-ins

### DIFF
--- a/pyblish_qml/models.py
+++ b/pyblish_qml/models.py
@@ -369,6 +369,10 @@ class ItemModel(AbstractModel):
         }.get(item["type"], "Other")
 
         for action in item["actions"]:
+            if action["__type__"] != "action":
+                # Consider only Actions, ignore Categories
+                continue
+
             if action["on"] == "all":
                 item["actionsIconVisible"] = True
 
@@ -532,7 +536,8 @@ class ItemModel(AbstractModel):
                     if action["on"] == "processed" and not item.processed:
                         actions.remove(action)
 
-                if actions:
+                if any(action["__type__"] == "action" for action in actions):
+                    # Consider only Actions, ignore Categories
                     item.actionsIconVisible = True
 
             # Update section item


### PR DESCRIPTION
This is a fix for #341 where the *"A"* Actions icons was visible on plug-ins when Categories were added to the actions yet there was not action currently available to run.

**What's changed?**

When deciding whether to enable `actionsIconVisible` we ignore any action which his `__type__` is not set to `action`, which is [the the case for Categories](https://github.com/pyblish/pyblish-base/blob/841f40821507964389adac01683ac86f745bb5fe/pyblish/plugin.py#L419). As such, now only whenever an action is available for processing with `__type__ == "action"` the icon will be visible on the plug-ins.