### PR TITLE
Prompt failed message at the end if any error occurred after validation (default test)

### DIFF
--- a/pyblish_qml/control.py
+++ b/pyblish_qml/control.py
@@ -936,7 +936,7 @@ class Controller(QtCore.QObject):
             model = self.data["models"]["item"]
             for instance in models.ItemIterator(model.instances):
                 if instance.hasError:
-                    self.info.emit("Publish failed..")
+                    self.info.emit("Published, with errors..")
                     break
 
         util.defer(get_data, callback=on_data_received)

--- a/pyblish_qml/control.py
+++ b/pyblish_qml/control.py
@@ -922,6 +922,14 @@ class Controller(QtCore.QObject):
         def on_finished():
             self.host.emit("published", context=None)
 
+            # If there are instance that has error, prompt failed message
+            # to footer.
+            model = self.data["models"]["item"]
+            for instance in models.ItemIterator(model.instances):
+                if instance.hasError:
+                    self.info.emit("Publish failed..")
+                    break
+
         util.defer(get_data, callback=on_data_received)
 
     @QtCore.pyqtSlot()

--- a/pyblish_qml/control.py
+++ b/pyblish_qml/control.py
@@ -76,7 +76,6 @@ class Controller(QtCore.QObject):
             },
             "comment": "",
             "firstRun": True,
-            "testPassed": False,
         }
 
         self.data.update({
@@ -109,7 +108,9 @@ class Controller(QtCore.QObject):
             "state": {
                 "is_running": False,
                 "current": None,
-                "all": list()
+                "all": list(),
+
+                "testPassed": False,
             }
         })
 
@@ -353,9 +354,9 @@ class Controller(QtCore.QObject):
                 raise StopIteration("Stopped")
 
             if test(**state):
-                self.data["testPassed"] = False
+                self.data["state"]["testPassed"] = False
                 raise StopIteration("Stopped due to %s" % test(**state))
-            self.data["testPassed"] = True
+            self.data["state"]["testPassed"] = True
 
             try:
                 # Notify GUI before commencing remote processing
@@ -925,7 +926,7 @@ class Controller(QtCore.QObject):
         def on_finished():
             self.host.emit("published", context=None)
 
-            if not self.data["testPassed"]:
+            if not self.data["state"]["testPassed"]:
                 # Possible stopped on validation fail or the extraction has
                 # been interrupted. Depend on the continual processing test.
                 return


### PR DESCRIPTION
This PR resolves #343, footer will show failed message if any instance got error during extraction or integration.

![qml](https://user-images.githubusercontent.com/3357009/65165826-1bdb6200-da72-11e9-9bef-f38cd4b51cae.gif)
