### PR TITLE
Update vendorized Qt.py

### DIFF
--- a/pyblish_qml/version.py
+++ b/pyblish_qml/version.py
@@ -1,7 +1,7 @@
 
 VERSION_MAJOR = 1
 VERSION_MINOR = 10
-VERSION_PATCH = 5
+VERSION_PATCH = 6
 
 version_info = (VERSION_MAJOR, VERSION_MINOR, VERSION_PATCH)
 version = '%i.%i.%i' % version_info


### PR DESCRIPTION
### What happened ?

When trying to launch Pyblish QML in Maya 2020, the following error raised.

```python
  File "C:\Users\david\Dropbox\github\AVALON\pyblish-qml\pyblish_qml\host.py", line 290, in __init__
    from .vendor.Qt import QtWidgets, QtCore, QtGui
  File "C:\Users\david\Dropbox\github\AVALON\pyblish-qml\pyblish_qml\vendor\Qt.py", line 1557, in <module>
    _install()
  File "C:\Users\david\Dropbox\github\AVALON\pyblish-qml\pyblish_qml\vendor\Qt.py", line 1509, in _install
    available[name]()
  File "C:\Users\david\Dropbox\github\AVALON\pyblish-qml\pyblish_qml\vendor\Qt.py", line 1037, in _pyside2
    _reassign_misplaced_members("PySide2")
  File "C:\Users\david\Dropbox\github\AVALON\pyblish-qml\pyblish_qml\vendor\Qt.py", line 922, in _reassign_misplaced_members
    dst_value = getattr(getattr(Qt, "_" + src_module), src_member)
AttributeError: 'module' object has no attribute 'QStringListModel'
```

### What's changed ?
* `vendor.Qt` updated to version `1.2.3`
