### PR TITLE
Fix registered targets lost when re-launching on existed server

### DIFF
--- a/pyblish_qml/app.py
+++ b/pyblish_qml/app.py
@@ -76,7 +76,7 @@ class Application(QtGui.QGuiApplication):
     inFocused = QtCore.pyqtSignal()
     outFocused = QtCore.pyqtSignal()
 
-    def __init__(self, source, targets=[]):
+    def __init__(self, source, targets=None):
         super(Application, self).__init__(sys.argv)
 
         self.setWindowIcon(QtGui.QIcon(ICON_PATH))
@@ -281,7 +281,7 @@ class Application(QtGui.QGuiApplication):
         thread.start()
 
 
-def main(demo=False, aschild=False, targets=[]):
+def main(demo=False, aschild=False, targets=None):
     """Start the Qt-runtime and show the window
 
     Arguments:

--- a/pyblish_qml/control.py
+++ b/pyblish_qml/control.py
@@ -61,13 +61,13 @@ class Controller(QtCore.QObject):
     resultModel = qtproperty(lambda self: self.data["models"]["result"])
     resultProxy = qtproperty(lambda self: self.data["proxies"]["result"])
 
-    def __init__(self, host, parent=None, targets=[]):
+    def __init__(self, host, parent=None, targets=None):
         super(Controller, self).__init__(parent)
 
         # Connection to host
         self.host = host
 
-        self.targets = targets
+        self.targets = targets or []
 
         self.data = {
             "models": {
@@ -984,7 +984,7 @@ class Controller(QtCore.QObject):
 
         util.defer(get_data, callback=on_data_received)
 
-    def run(self, plugins, context, callback=None, callback_args=[]):
+    def run(self, plugins, context, callback=None, callback_args=None):
         """Commence asynchronous tasks
 
         This method runs through the provided `plugins` in
@@ -1001,6 +1001,7 @@ class Controller(QtCore.QObject):
             callback_args (list, optional): Arguments passed to callback
 
         """
+        callback_args = callback_args or []
 
         # if "ready" not in self.states:
         #     return self.error.emit("Not ready")

--- a/pyblish_qml/host.py
+++ b/pyblish_qml/host.py
@@ -77,7 +77,7 @@ def uninstall():
 
 
 def show(parent=None,
-         targets=[],
+         targets=None,
          modal=None,
          auto_publish=False,
          auto_validate=False):
@@ -110,8 +110,9 @@ def show(parent=None,
         proxy = ipc.server.Proxy(server)
 
         try:
-            # Update target
-            proxy.target(targets)
+            if targets:
+                # Update targets
+                proxy.target(targets)
             proxy.show(show_settings)
             return server
 

--- a/pyblish_qml/host.py
+++ b/pyblish_qml/host.py
@@ -97,6 +97,12 @@ def show(parent=None,
     if modal is None:
         modal = bool(os.environ.get("PYBLISH_QML_MODAL", False))
 
+    if not targets:
+        # If no targets are passed to pyblish-qml, we assume that we want the
+        # default target and the registered targets. This is to facilitate
+        # getting all plugins on pyblish_qml.show().
+        targets = ["default"] + pyblish.api.registered_targets()
+
     # Automatically install if not already installed.
     install(modal)
 
@@ -110,9 +116,8 @@ def show(parent=None,
         proxy = ipc.server.Proxy(server)
 
         try:
-            if targets:
-                # Update targets
-                proxy.target(targets)
+            # Update targets
+            proxy.target(targets)
             proxy.show(show_settings)
             return server
 

--- a/pyblish_qml/ipc/server.py
+++ b/pyblish_qml/ipc/server.py
@@ -116,7 +116,7 @@ class Server(object):
                  service,
                  python=None,
                  pyqt5=None,
-                 targets=[],
+                 targets=None,
                  modal=False,
                  environ=None):
 

--- a/pyblish_qml/ipc/server.py
+++ b/pyblish_qml/ipc/server.py
@@ -201,14 +201,7 @@ class Server(object):
             # from opening an external terminal window.
             kwargs["creationflags"] = CREATE_NO_WINDOW
 
-        # If no targets are passed to pyblish-qml, we assume that we want the
-        # default target and the registered targets. This is to facilitate
-        # getting all plugins on pyblish_qml.show().
-        import pyblish.api
-        if not targets:
-            targets = ["default"] + pyblish.api.registered_targets()
         print("Targets: {0}".format(", ".join(targets)))
-
         kwargs["args"].append("--targets")
         kwargs["args"].extend(targets)
 


### PR DESCRIPTION
This was reported in Gitter 👉 [February 3, 2020 4:54 PM](https://gitter.im/pyblish/pyblish?at=5e37dfb6fe0e6f74e9fbd502) from @BigRoy .

It was a bug after #347, it was trying to solve #335 which was assigning and changing targets via `pyblish_qml.api.show`. But the solution did not pay attention to the case that is using targets from `pyblish.api.registered_targets`, hence we got the bug.

### Reproducible
```python
import pyblish.api
import pyblish_qml.api

# Register some random target.
pyblish.api.register_target("custom")
# Launch !
pyblish_qml.api.show()
# Now navigate to the `Terminal` page on top of GUI, should see our target "custom" in view.
# While window still exists, launch again.
pyblish_qml.api.show()
# Targets has been wiped..

```

### What's changed
* Only updating targets to current server if `targets` is provided
* Default value of `targets` changes to `None` instead of mutable `list`
