### PR TITLE
Implementing "Post Collect"

### DIFF
--- a/pyblish_qml/control.py
+++ b/pyblish_qml/control.py
@@ -843,6 +843,7 @@ class Controller(QtCore.QObject):
 
         def on_discover(plugins, context):
             collectors = list()
+            model = self.data["models"]["item"]
 
             # For backwards compatibility check for existance of
             # "plugins_by_targets" method.
@@ -850,7 +851,7 @@ class Controller(QtCore.QObject):
                 plugins = pyblish.api.plugins_by_targets(plugins, self.targets)
 
             for plugin in plugins:
-                self.data["models"]["item"].add_plugin(plugin.to_json())
+                model.add_plugin(plugin.to_json())
 
                 # Sort out which of these are Collectors
                 if not pyblish.lib.inrange(
@@ -859,6 +860,8 @@ class Controller(QtCore.QObject):
                     continue
 
                 if plugin.order >= context.data["postCollectOrder"]:
+                    model.plugins[-1].verb = "Additional"
+                    model.add_section("Additional")
                     continue
 
                 if not plugin.active:

--- a/pyblish_qml/ipc/formatting.py
+++ b/pyblish_qml/ipc/formatting.py
@@ -195,6 +195,13 @@ def format_context(context):
     }
 
 
+def format_post_collect_order(order):
+    try:
+        return float(order)
+    except (TypeError, ValueError):
+        return float("NaN")
+
+
 def format_plugins(plugins):
     """Serialise multiple plug-in
 

--- a/pyblish_qml/ipc/formatting.py
+++ b/pyblish_qml/ipc/formatting.py
@@ -142,6 +142,7 @@ def format_data(data):
         "port",
         "user",
         "connectTime",
+        "postCollectOrder",
         "pyblishVersion",
         "pyblishRPCVersion",
         "pythonVersion")

--- a/pyblish_qml/ipc/service.py
+++ b/pyblish_qml/ipc/service.py
@@ -56,10 +56,12 @@ class Service(object):
         # Append additional metadata to context
         port = os.environ.get("PYBLISH_CLIENT_PORT", -1)
         hosts = ", ".join(reversed(pyblish.api.registered_hosts()))
+        post_collect = float(os.environ.get("PYBLISH_QML_POST_COLLECT", "NaN"))
 
         for key, value in {"host": hosts,
                            "port": int(port),
                            "user": getpass.getuser(),
+                           "postCollectOrder": post_collect,
                            "connectTime": pyblish.lib.time(),
                            "pyblishVersion": pyblish.version,
                            "pythonVersion": sys.version}.items():

--- a/pyblish_qml/ipc/service.py
+++ b/pyblish_qml/ipc/service.py
@@ -28,6 +28,7 @@ class Service(object):
         self._context = None
         self._plugins = None
         self._provider = None
+        self._post_collect = None
 
         self.reset()
 
@@ -51,17 +52,18 @@ class Service(object):
         self._context = pyblish.api.Context()
         self._plugins = pyblish.api.discover()
         self._provider = pyblish.plugin.Provider()
+        self._post_collect = formatting.format_post_collect_order(
+            os.environ.get("PYBLISH_QML_POST_COLLECT"))
 
     def context(self):
         # Append additional metadata to context
         port = os.environ.get("PYBLISH_CLIENT_PORT", -1)
         hosts = ", ".join(reversed(pyblish.api.registered_hosts()))
-        post_collect = float(os.environ.get("PYBLISH_QML_POST_COLLECT", "NaN"))
 
         for key, value in {"host": hosts,
                            "port": int(port),
                            "user": getpass.getuser(),
-                           "postCollectOrder": post_collect,
+                           "postCollectOrder": self._post_collect,
                            "connectTime": pyblish.lib.time(),
                            "pyblishVersion": pyblish.version,
                            "pythonVersion": sys.version}.items():

--- a/pyblish_qml/models.py
+++ b/pyblish_qml/models.py
@@ -83,6 +83,7 @@ defaults = {
         "port": 0,
         "host": "default",
         "user": "default",
+        "postCollectOrder": float("NaN"),
         "connectTime": "default",
         "pythonVersion": "default",
         "pyblishVersion": "default",

--- a/pyblish_qml/qml/delegates/ContextDelegate.qml
+++ b/pyblish_qml/qml/delegates/ContextDelegate.qml
@@ -48,6 +48,10 @@ BaseDelegate {
                     "value": object.targets
                 },
                 {
+                    "key": "Post Collect",
+                    "value": object.postCollectOrder
+                },
+                {
                     "key": "Connected",
                     "value": Date(Date.parse(object.connectTime))
                 }]


### PR DESCRIPTION
This PR should resolves pyblish/pyblish-base#359, an experimental feature called "Post Collect".

The "Post Collect" is a GUI behavior that will make Pyblish-QML stop running collector plugins at a given point, and let user to decide which instance may continue the rest CVEI and which not.

### Usage
Require an extra environment variable `PYBLISH_QML_POST_COLLECT` to provide the break point, the value is a string of float. The number shoule be inside the range of Pyblish's Collecting.

Here's an example: https://gist.github.com/davidlatwe/9c39e5ef05140d6ba98f0914ed46f5ed

And the working result:

![post-collect-new](https://user-images.githubusercontent.com/3357009/73921892-2acc8f00-4903-11ea-976b-bb3369b9301c.gif)
