### PR TITLE
Fix error handling within iterator

### DIFF
--- a/pyblish_qml/control.py
+++ b/pyblish_qml/control.py
@@ -1022,7 +1022,7 @@ class Controller(QtCore.QObject):
         # For each completed task, update
         # the GUI and commence next task.
         def on_next(result):
-            if isinstance(result, StopIteration):
+            if isinstance(result, Exception):
                 return on_finished(str(result))
 
             self.data["models"]["item"].update_with_result(result)
@@ -1157,7 +1157,7 @@ class Controller(QtCore.QObject):
             if not self.data["state"]["is_running"]:
                 return on_finished()
 
-            if isinstance(result, StopIteration):
+            if isinstance(result, Exception):
                 return on_finished()
 
             if isinstance(result, pyblish.logic.TestFailed):


### PR DESCRIPTION
This resolves #353

Tested with PySide2 and Python 2.7, Python 3.7 and Python 3.8 with the demo window:

```
python -m pyblish_qml --demo --targets default
```
(took me a while to figure out that I had to pass the 'default' target to see something!)

I didn't deal with unit tests as I am unfamiliar with nose, please let me know if you want me to handle it.

