### PR TITLE
Fix custom registered test not being passed from client to server

### DIFF
--- a/pyblish_qml/app.py
+++ b/pyblish_qml/app.py
@@ -241,7 +241,7 @@ class Application(QtGui.QGuiApplication):
         def _listen():
             while True:
                 line = self.host.channels["parent"].get()
-                payload = json.loads(line)["payload"]
+                payload = json.loads(line, cls=util.SetJSONDecoder)["payload"]
 
                 # We can't call methods directly, as we are running
                 # in a thread. Instead, we emit signals that do the

--- a/pyblish_qml/app.py
+++ b/pyblish_qml/app.py
@@ -241,7 +241,7 @@ class Application(QtGui.QGuiApplication):
         def _listen():
             while True:
                 line = self.host.channels["parent"].get()
-                payload = json.loads(line, cls=util.SetJSONDecoder)["payload"]
+                payload = json.loads(line)["payload"]
 
                 # We can't call methods directly, as we are running
                 # in a thread. Instead, we emit signals that do the

--- a/pyblish_qml/control.py
+++ b/pyblish_qml/control.py
@@ -329,7 +329,6 @@ class Controller(QtCore.QObject):
 
         """
 
-        test = pyblish.logic.registered_test()
         state = {
             "nextOrder": None,
             "ordersWithError": set()
@@ -355,9 +354,10 @@ class Controller(QtCore.QObject):
             if not self.data["state"]["is_running"]:
                 return StopIteration("Stopped")
 
-            if test(**state):
+            test_result = self.host.test(**state)
+            if test_result:
                 self.data["state"]["testPassed"] = False
-                return StopIteration("Stopped due to %s" % test(**state))
+                return StopIteration("Stopped due to %s" % test_result)
 
             self.data["state"]["testPassed"] = True
 

--- a/pyblish_qml/ipc/client.py
+++ b/pyblish_qml/ipc/client.py
@@ -21,6 +21,7 @@ import threading
 import pyblish.api
 import pyblish.plugin
 
+from ..util import SetJSONEncoder, SetJSONDecoder
 from ..vendor import six
 from ..vendor.six.moves import queue
 
@@ -142,7 +143,7 @@ class Proxy(object):
         thread.daemon = True
         thread.start()
 
-    def _dispatch(self, func, args=None):
+    def _dispatch(self, func, args=None, kwargs=None):
         """Send message to parent process
 
         Arguments:
@@ -157,8 +158,10 @@ class Proxy(object):
                 "payload": {
                     "name": func,
                     "args": args or list(),
+                    "kwargs": kwargs or dict(),
                 }
-            }
+            },
+            cls=SetJSONEncoder,
         )
 
         # This should never happen. Each request is immediately
@@ -178,9 +181,9 @@ class Proxy(object):
             message = self.channels["response"].get()
 
             if six.PY3:
-                response = json.loads(message)
+                response = json.loads(message, cls=SetJSONDecoder)
             else:
-                response = _byteify(json.loads(message, object_hook=_byteify))
+                response = _byteify(json.loads(message, object_hook=_byteify, cls=SetJSONDecoder))
 
         except TypeError as e:
             raise e

--- a/pyblish_qml/ipc/client.py
+++ b/pyblish_qml/ipc/client.py
@@ -21,7 +21,6 @@ import threading
 import pyblish.api
 import pyblish.plugin
 
-from ..util import SetJSONEncoder, SetJSONDecoder
 from ..vendor import six
 from ..vendor.six.moves import queue
 
@@ -49,6 +48,10 @@ class Proxy(object):
 
     def test(self, **vars):
         """Vars can only be passed as a non-keyword argument"""
+
+        # -> Support JSON, see #364
+        vars["ordersWithError"] = list(vars["ordersWithError"])
+
         return self._dispatch("test", kwargs=vars)
 
     def ping(self):
@@ -160,8 +163,7 @@ class Proxy(object):
                     "args": args or list(),
                     "kwargs": kwargs or dict(),
                 }
-            },
-            cls=SetJSONEncoder,
+            }
         )
 
         # This should never happen. Each request is immediately
@@ -181,9 +183,9 @@ class Proxy(object):
             message = self.channels["response"].get()
 
             if six.PY3:
-                response = json.loads(message, cls=SetJSONDecoder)
+                response = json.loads(message)
             else:
-                response = _byteify(json.loads(message, object_hook=_byteify, cls=SetJSONDecoder))
+                response = _byteify(json.loads(message, object_hook=_byteify))
 
         except TypeError as e:
             raise e

--- a/pyblish_qml/ipc/server.py
+++ b/pyblish_qml/ipc/server.py
@@ -22,7 +22,6 @@ import subprocess
 import time
 
 from .. import _state
-from ..util import SetJSONEncoder, SetJSONDecoder
 from ..vendor import six
 
 CREATE_NO_WINDOW = 0x08000000
@@ -91,7 +90,6 @@ class Proxy(object):
                     "kwargs": kwargs or dict(),
                 }
             },
-            cls=SetJSONEncoder,
         )
 
         if six.PY3:
@@ -245,7 +243,7 @@ class Server(object):
                     line = line.decode("utf8")
 
                 try:
-                    response = json.loads(line, cls=SetJSONDecoder)
+                    response = json.loads(line)
                 except Exception:
                     if last_msg_newline:
                         # last newline message was a real newline
@@ -292,7 +290,6 @@ class Server(object):
                                 "header": "pyblish-qml:popen.response",
                                 "payload": result
                             },
-                            cls=SetJSONEncoder,
                         )
 
                         if six.PY3:

--- a/pyblish_qml/ipc/service.py
+++ b/pyblish_qml/ipc/service.py
@@ -31,7 +31,7 @@ class Service(object):
 
         self.reset()
 
-    def test(self, vars):
+    def test(self, **vars):
         test = pyblish.logic.registered_test()
         return test(**vars)
 

--- a/pyblish_qml/ipc/service.py
+++ b/pyblish_qml/ipc/service.py
@@ -33,6 +33,10 @@ class Service(object):
 
     def test(self, **vars):
         test = pyblish.logic.registered_test()
+
+        # -> Support test, see #364
+        vars["ordersWithError"] = set(vars["ordersWithError"])
+
         return test(**vars)
 
     def ping(self):

--- a/pyblish_qml/util.py
+++ b/pyblish_qml/util.py
@@ -295,35 +295,3 @@ def SlotSentinel(*args):
         return wrapper
 
     return slotdecorator
-
-
-class SetJSONEncoder(json.JSONEncoder):
-    """JSON encoder that supports encoding Python sets"""
-    def default(self, obj):
-        if isinstance(obj, set):
-            return {"_python_set": list(obj)}
-        return json.JSONEncoder.default(self, obj)
-
-
-class SetJSONDecoder(json.JSONDecoder):
-    """JSON decoder that supports decoding Python sets"""
-    def decode(self, s, **kwargs):
-        decoded = super(SetJSONDecoder, self).decode(s, **kwargs)
-        return self._convert_python_sets(decoded)
-
-    @classmethod
-    def _convert_python_sets(cls, obj):
-        if isinstance(obj, dict):
-            if "_python_set" in obj:
-                return set(cls._convert_python_sets(obj["_python_set"]))
-            else:
-                new_obj = dict()
-                for key, value in obj.items():
-                    new_obj[key] = cls._convert_python_sets(value)
-                return new_obj
-        elif isinstance(obj, list):
-            new_obj = list()
-            for value in obj:
-                new_obj.append(cls._convert_python_sets(value))
-            return new_obj
-        return obj

--- a/pyblish_qml/util.py
+++ b/pyblish_qml/util.py
@@ -1,3 +1,4 @@
+import json
 import re
 import time
 import types
@@ -294,3 +295,35 @@ def SlotSentinel(*args):
         return wrapper
 
     return slotdecorator
+
+
+class SetJSONEncoder(json.JSONEncoder):
+    """JSON encoder that supports encoding Python sets"""
+    def default(self, obj):
+        if isinstance(obj, set):
+            return {"_python_set": list(obj)}
+        return json.JSONEncoder.default(self, obj)
+
+
+class SetJSONDecoder(json.JSONDecoder):
+    """JSON decoder that supports decoding Python sets"""
+    def decode(self, s, **kwargs):
+        decoded = super(SetJSONDecoder, self).decode(s, **kwargs)
+        return self._convert_python_sets(decoded)
+
+    @classmethod
+    def _convert_python_sets(cls, obj):
+        if isinstance(obj, dict):
+            if "_python_set" in obj:
+                return set(cls._convert_python_sets(obj["_python_set"]))
+            else:
+                new_obj = dict()
+                for key, value in obj.items():
+                    new_obj[key] = cls._convert_python_sets(value)
+                return new_obj
+        elif isinstance(obj, list):
+            new_obj = list()
+            for value in obj:
+                new_obj.append(cls._convert_python_sets(value))
+            return new_obj
+        return obj


### PR DESCRIPTION
This is a fix for a bug where the registered test function (i.e. the function registered with `pyblish.logic.register_test`) is not passed from the pyblish-qml client to the server, which ends up always using the default test function.

The issue was discussed with more details and a code sample here: https://github.com/pyblish/pyblish-qml/issues/363