### PR TITLE
Fix KeyError when calling pyblish_qml.show() more than once

### DIFF
--- a/pyblish_qml/host.py
+++ b/pyblish_qml/host.py
@@ -191,8 +191,14 @@ def install_callbacks():
 
 
 def uninstall_callbacks():
-    pyblish.api.deregister_callback("instanceToggled", _toggle_instance)
-    pyblish.api.deregister_callback("pluginToggled", _toggle_plugin)
+    try:
+        pyblish.api.deregister_callback("instanceToggled", _toggle_instance)
+    except (KeyError, ValueError):
+        pass
+    try:
+        pyblish.api.deregister_callback("pluginToggled", _toggle_plugin)
+    except (KeyError, ValueError):
+        pass
 
 
 def _toggle_instance(instance, new_value, old_value):


### PR DESCRIPTION
It seem that since pyblish-qml-1.9.6, a KeyError is raised when calling `pyblish_qml.show()` more than once if `pyblish.api.deregister_all_callbacks()` is called before the second call.

This is the stack trace:
```
# Traceback (most recent call last):
#   File "<maya console>", line 148, in <module>
#   File "/softwareLocal/rez_python_envs/shared/2.7.16/0xb578cca6b312bb8d/lib/python2.7/site-packages/pyblish_qml/__init__.py", line 21, in show
#     return host.show(parent, targets, modal, auto_publish, auto_validate)
#   File "/softwareLocal/rez_python_envs/shared/2.7.16/0xb578cca6b312bb8d/lib/python2.7/site-packages/pyblish_qml/host.py", line 107, in show
#     install(modal)
#   File "/softwareLocal/rez_python_envs/shared/2.7.16/0xb578cca6b312bb8d/lib/python2.7/site-packages/pyblish_qml/host.py", line 63, in install
#     uninstall()
#   File "/softwareLocal/rez_python_envs/shared/2.7.16/0xb578cca6b312bb8d/lib/python2.7/site-packages/pyblish_qml/host.py", line 75, in uninstall
#     uninstall_callbacks()
#   File "/softwareLocal/rez_python_envs/shared/2.7.16/0xb578cca6b312bb8d/lib/python2.7/site-packages/pyblish_qml/host.py", line 194, in uninstall_callbacks
#     pyblish.api.deregister_callback("instanceToggled", _toggle_instance)
#   File "/softwareLocal/rez_python_envs/shared/2.7.16/0xb578cca6b312bb8d/lib/python2.7/site-packages/pyblish/plugin.py", line 910, in deregister_callback
#     _registered_callbacks[signal].remove(callback)
# KeyError: 'instanceToggled' # 
```

I believe this is this the commit that exposed the issue: https://github.com/pyblish/pyblish-qml/commit/e4dacaa075f3e535fe8a706b7a1808ef1defcbde

I've seen in other places of the code that we deal with this case with a simple try/except, so I've the done the same in my fix here.