### PR TITLE
Relax pyblish-base version dependency.

### DIFF
--- a/pyblish_qml/version.py
+++ b/pyblish_qml/version.py
@@ -1,7 +1,7 @@
 
 VERSION_MAJOR = 1
 VERSION_MINOR = 11
-VERSION_PATCH = 3
+VERSION_PATCH = 4
 
 version_info = (VERSION_MAJOR, VERSION_MINOR, VERSION_PATCH)
 version = '%i.%i.%i' % version_info

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,0 @@
-pyblish-base>=1.4

--- a/setup.py
+++ b/setup.py
@@ -78,7 +78,7 @@ setup(
         ]
     },
     install_requires=[
-        "pyblish-base==1.5.3"
+        "pyblish-base>=1.5.3"
     ],
     entry_points={},
 )


### PR DESCRIPTION
Closes #337 

I'm not sure this actually sets the version dependency appropriately, but pyblish-qml almost certainly shouldn't be explicitly depending on such an old version of pyblish-base as it is now.