### PR TITLE
fix TypeError spam when opening QML

### DIFF
--- a/pyblish_qml/qml/List.qml
+++ b/pyblish_qml/qml/List.qml
@@ -25,7 +25,8 @@ ListView {
         checked: object.isToggled
         hidden: object.isHidden
 
-        width: parent.width
+        width: if (parent)
+                    parent.width
 
         status: {
             if (object.isProcessing)

--- a/pyblish_qml/qml/List.qml
+++ b/pyblish_qml/qml/List.qml
@@ -25,8 +25,7 @@ ListView {
         checked: object.isToggled
         hidden: object.isHidden
 
-        width: if (parent)
-                    parent.width
+        width: parent ? parent.width : 0
 
         status: {
             if (object.isProcessing)


### PR DESCRIPTION
this PR fixes the following:
when opening QML the console always spams errors 
```
Entering state: "initialising"
Entering state: "collecting"
WARN (bpy.rna): C:\Users\blender\git\blender-v300\blender.git\source\blender\python\intern\bpy_rna.c:1352 pyrna_enum_to_py: current value '0' matches no enum in 'ColorManagedInputColorspaceSettings', '(null)', 'name'
Not ready, hold SHIFT to force an exit
Spent 1286.91 ms resetting
Made 0 requests during publish.
file:///C:/Users/REDACTED/pyblish_qml/qml/List.qml:28: TypeError: Cannot read property 'width' of null
file:///C:/Users/REDACTED/pyblish_qml/qml/List.qml:28: TypeError: Cannot read property 'width' of null
file:///C:/Users/REDACTED/pyblish_qml/qml/List.qml:28: TypeError: Cannot read property 'width' of null
file:///C:/Users/REDACTED/pyblish_qml/qml/List.qml:28: TypeError: Cannot read property 'width' of null
file:///C:/Users/REDACTED/pyblish_qml/qml/List.qml:28: TypeError: Cannot read property 'width' of null
file:///C:/Users/REDACTED/pyblish_qml/qml/List.qml:28: TypeError: Cannot read property 'width' of null
file:///C:/Users/REDACTED/pyblish_qml/qml/List.qml:28: TypeError: Cannot read property 'width' of null
file:///C:/Users/REDACTED/pyblish_qml/qml/List.qml:28: TypeError: Cannot read property 'width' of null
file:///C:/Users/REDACTED/pyblish_qml/qml/List.qml:28: TypeError: Cannot read property 'width' of null
file:///C:/Users/REDACTED/pyblish_qml/qml/List.qml:28: TypeError: Cannot read property 'width' of null
file:///C:/Users/REDACTED/pyblish_qml/qml/List.qml:28: TypeError: Cannot read property 'width' of null
file:///C:/Users/REDACTED/pyblish_qml/qml/List.qml:28: TypeError: Cannot read property 'width' of null
```