### PR TITLE
Fix5.15

### DIFF
--- a/pyblish_qml/control.py
+++ b/pyblish_qml/control.py
@@ -306,7 +306,7 @@ class Controller(QtCore.QObject):
     def state(self):
         return self.data["state"]["current"]
 
-    @QtCore.Property(bool, constant=True)
+    @QtCore.Property(bool)
     def commentEnabled(self):
         return "comment" in self.host.cached_context.data
 

--- a/pyblish_qml/ipc/server.py
+++ b/pyblish_qml/ipc/server.py
@@ -135,7 +135,7 @@ class Server(object):
         python = python or find_python()
         print("Using Python @ '%s'" % python)
 
-        pyqt5 = pyqt5 or find_pyqt5(python)
+        pyqt5 = pyqt5 or find_qt(python)
         print("Using PyQt5 @ '%s'" % pyqt5)
 
         # Maintain the absolute minimum of environment variables,
@@ -380,10 +380,11 @@ def find_python():
     return python
 
 
-def find_pyqt5(python):
+def find_qt(python):
     """Search for PyQt5 automatically"""
     pyqt5 = (
         _state.get("pyqt5") or
+        os.getenv("PYBLISH_QML_PYSIDE2") or
         os.getenv("PYBLISH_QML_PYQT5")
     )
 


### PR DESCRIPTION
Wasn't working in Qt 5.15 for some obscure reason, now it does. Also added the ability to specify a path to PySide2.

```bash
export PYBLISH_QML_PYSIDE2=/some/path/to/site-packages/with-pyside2
```