### PR TITLE
Fix Python 2 bug in argument specification handling for wrapper registration

### DIFF
--- a/pyblish_qml/host.py
+++ b/pyblish_qml/host.py
@@ -12,8 +12,17 @@ from .vendor.six.moves import queue
 from .vendor import six
 
 if six.PY2:
-    get_arg_spec = inspect.getargspec
-    get_arg_spec.varkw = get_arg_spec.keywords
+    class __FullArgSpec(object):
+        def __init__(self, func):
+            spec = inspect.getargspec(func)
+            self.args = spec.args
+            self.varargs = spec.varargs
+            self.varkw = spec.keywords
+            self.defaults = spec.defaults
+            self.kwonlyargs = []
+            self.kwonlydefaults = None
+            self.annotations = {}
+    get_arg_spec = __FullArgSpec
 else:
     get_arg_spec = inspect.getfullargspec
 


### PR DESCRIPTION
This PR fixes a bug in the argument specification handling when registering dispatch wrappers, which leads to an AttributeError in Python 2 environments.

### Context
https://github.com/pyblish/pyblish-qml/pull/381/commits/769eafc9ffe0dead5aa7728b795e4d1fe3dd061a
In a previous change, the following code was introduced for handling argument specifications:

```python
if six.PY2:
    get_arg_spec = inspect.getargspec
    get_arg_spec.varkw = get_arg_spec.keywords
else:
    get_arg_spec = inspect.getfullargspec
```
The issue here is that `get_arg_spec.varkw = get_arg_spec.keywords` incorrectly tries to assign `varkw` directly to the `getargspec` function itself, rather than handling this on a per-function basis. This leads to the following error when checking the signature of wrapper functions:

### Fix
This PR introduces a custom __FullArgSpec class for Python 2, ensuring that argument specifications are correctly retrieved and that varkw is properly mapped from keywords at the instance level, not at the function level. This resolves the AttributeError and ensures that dispatch wrappers are properly registered without signature mismatches in Python 2.

Please review and let me know if further changes are required!